### PR TITLE
fix: commands could not invoke the plugin's own helper script

### DIFF
--- a/.claude/commands/context.md
+++ b/.claude/commands/context.md
@@ -17,13 +17,17 @@ For deep or repository-wide search, delegate to the built-in `Explore` agent rat
 ## Live Project Data
 
 ### Recent commits
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh recent-commits`
+> The commands in this section must be run with the Bash tool; they cannot be
+> pre-executed in a `!` block. A `!` block is permission-checked before
+> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh recent-commits`
 
 ### Active branch
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
 
 ### Directory structure (top 2 levels)
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh project-files`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh project-files`
 
 ## Output Format
 

--- a/.claude/commands/pr-summary.md
+++ b/.claude/commands/pr-summary.md
@@ -7,13 +7,17 @@ Generate a comprehensive pull request summary from the data below.
 ## Live Branch Data
 
 ### Commits on this branch
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh pr-commits`
+> The commands in this section must be run with the Bash tool; they cannot be
+> pre-executed in a `!` block. A `!` block is permission-checked before
+> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh pr-commits`
 
 ### Files changed
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh pr-files`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh pr-files`
 
 ### Diff stats
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh pr-stats`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh pr-stats`
 
 ## Output Format
 

--- a/.claude/commands/speckit.analyze.md
+++ b/.claude/commands/speckit.analyze.md
@@ -9,16 +9,20 @@ Perform a read-only consistency analysis across all spec-kit artifacts for the c
 ## Pre-Flight
 
 ### Current branch
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
+> The commands in this section must be run with the Bash tool; they cannot be
+> pre-executed in a `!` block. A `!` block is permission-checked before
+> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
 
 ### Load all artifacts
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh all-artifacts`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh all-artifacts`
 
 ### Constitution
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh constitution`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh constitution`
 
 ### Checklists
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh checklists-content`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh checklists-content`
 
 ## Instructions
 

--- a/.claude/commands/speckit.baseline.md
+++ b/.claude/commands/speckit.baseline.md
@@ -10,16 +10,20 @@ Reverse-engineer a specification from existing code in: **$ARGUMENTS**
 ## Pre-Flight
 
 ### Current branch
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
+> The commands in this section must be run with the Bash tool; they cannot be
+> pre-executed in a `!` block. A `!` block is permission-checked before
+> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
 
 ### .specify directory
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh check-specify-dir`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh check-specify-dir`
 
 ### Existing code
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh detect-existing-code`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh detect-existing-code`
 
 ### Constitution
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh constitution`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh constitution`
 
 ## Instructions
 

--- a/.claude/commands/speckit.brainstorm.md
+++ b/.claude/commands/speckit.brainstorm.md
@@ -10,13 +10,17 @@ Explore and refine the idea before writing a formal spec: **$ARGUMENTS**
 ## Pre-Flight
 
 ### Current branch
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
+> The commands in this section must be run with the Bash tool; they cannot be
+> pre-executed in a `!` block. A `!` block is permission-checked before
+> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
 
 ### Project context
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh detect-stack`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh detect-stack`
 
 ### Existing specs
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh list-specs-dir`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh list-specs-dir`
 
 ## Hard Gate
 

--- a/.claude/commands/speckit.checklist.md
+++ b/.claude/commands/speckit.checklist.md
@@ -9,13 +9,17 @@ Generate requirement quality checklists (NOT implementation tests) for the curre
 ## Pre-Flight
 
 ### Current branch
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
+> The commands in this section must be run with the Bash tool; they cannot be
+> pre-executed in a `!` block. A `!` block is permission-checked before
+> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
 
 ### Load spec
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh spec`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh spec`
 
 ### Existing checklists
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh checklists-dir`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh checklists-dir`
 
 ## Instructions
 

--- a/.claude/commands/speckit.clarify.md
+++ b/.claude/commands/speckit.clarify.md
@@ -9,13 +9,17 @@ Scan the current branch's specification for ambiguities and generate targeted cl
 ## Pre-Flight
 
 ### Current branch
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
+> The commands in this section must be run with the Bash tool; they cannot be
+> pre-executed in a `!` block. A `!` block is permission-checked before
+> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
 
 ### Load spec
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh spec`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh spec`
 
 ### Existing clarifications
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh clarifications`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh clarifications`
 
 ## Instructions
 

--- a/.claude/commands/speckit.constitution.md
+++ b/.claude/commands/speckit.constitution.md
@@ -9,16 +9,20 @@ Create or update the project constitution at `.specify/memory/constitution.md`.
 ## Pre-Flight
 
 ### Existing constitution
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh constitution`
+> The commands in this section must be run with the Bash tool; they cannot be
+> pre-executed in a `!` block. A `!` block is permission-checked before
+> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh constitution`
 
 ### Project context
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh readme-head`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh readme-head`
 
 ### Tech stack detection
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh list-config-files`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh list-config-files`
 
 ### Existing rules
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh list-rules`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh list-rules`
 
 ## Instructions
 

--- a/.claude/commands/speckit.fix.md
+++ b/.claude/commands/speckit.fix.md
@@ -10,10 +10,14 @@ Apply a quick fix for: **$ARGUMENTS**
 ## Pre-Flight
 
 ### Current branch
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
+> The commands in this section must be run with the Bash tool; they cannot be
+> pre-executed in a `!` block. A `!` block is permission-checked before
+> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
 
 ### Change scope
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh trivial-change-check`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh trivial-change-check`
 
 ## Instructions
 

--- a/.claude/commands/speckit.implement.md
+++ b/.claude/commands/speckit.implement.md
@@ -9,19 +9,23 @@ Execute the implementation plan using strict TDD cycles with quality gates.
 ## Pre-Flight
 
 ### Current branch
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
+> The commands in this section must be run with the Bash tool; they cannot be
+> pre-executed in a `!` block. A `!` block is permission-checked before
+> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
 
 ### Load artifacts
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh check-artifacts`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh check-artifacts`
 
 ### Constitution
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh constitution`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh constitution`
 
 ### Checklists
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh checklists`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh checklists`
 
 ### Test framework detection
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh detect-test-framework`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh detect-test-framework`
 
 ## Instructions
 

--- a/.claude/commands/speckit.init.md
+++ b/.claude/commands/speckit.init.md
@@ -9,10 +9,14 @@ Bootstrap a `.specify/` directory in the current project to enable spec-driven d
 ## Pre-Flight Checks
 
 ### Git root detection
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh check-git-root`
+> The commands in this section must be run with the Bash tool; they cannot be
+> pre-executed in a `!` block. A `!` block is permission-checked before
+> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh check-git-root`
 
 ### Existing .specify/ detection
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh check-specify-dir`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh check-specify-dir`
 
 ## Instructions
 

--- a/.claude/commands/speckit.plan.md
+++ b/.claude/commands/speckit.plan.md
@@ -9,19 +9,23 @@ Generate an implementation plan from the current branch's specification.
 ## Pre-Flight
 
 ### Current branch
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
+> The commands in this section must be run with the Bash tool; they cannot be
+> pre-executed in a `!` block. A `!` block is permission-checked before
+> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
 
 ### Auto-detect spec branch
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh check-spec`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh check-spec`
 
 ### Available specs
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh list-specs`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh list-specs`
 
 ### Constitution
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh constitution`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh constitution`
 
 ### Start plan phase (RIPER-style write-block)
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh plan-phase-start`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh plan-phase-start`
 
 ## Instructions
 

--- a/.claude/commands/speckit.review.md
+++ b/.claude/commands/speckit.review.md
@@ -9,19 +9,23 @@ Review the implementation plan before generating tasks.
 ## Pre-Flight
 
 ### Current branch
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
+> The commands in this section must be run with the Bash tool; they cannot be
+> pre-executed in a `!` block. A `!` block is permission-checked before
+> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
 
 ### Plan status
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh check-plan-review`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh check-plan-review`
 
 ### Load spec
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh spec`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh spec`
 
 ### Load plan
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh plan`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh plan`
 
 ### Constitution
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh constitution`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh constitution`
 
 ## Instructions
 

--- a/.claude/commands/speckit.specify.md
+++ b/.claude/commands/speckit.specify.md
@@ -10,16 +10,20 @@ Generate a structured specification for: **$ARGUMENTS**
 ## Pre-Flight
 
 ### Git status
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
+> The commands in this section must be run with the Bash tool; they cannot be
+> pre-executed in a `!` block. A `!` block is permission-checked before
+> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
 
 ### Constitution
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh constitution`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh constitution`
 
 ### Existing specs
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh list-specs-dir`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh list-specs-dir`
 
 ### Project structure
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh detect-stack`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh detect-stack`
 
 ## Instructions
 

--- a/.claude/commands/speckit.tasks.md
+++ b/.claude/commands/speckit.tasks.md
@@ -9,16 +9,20 @@ Generate a phased task list from the current branch's plan and specification.
 ## Pre-Flight
 
 ### Current branch
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
+> The commands in this section must be run with the Bash tool; they cannot be
+> pre-executed in a `!` block. A `!` block is permission-checked before
+> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh branch`
 
 ### Auto-detect spec branch
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh check-plan`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh check-plan`
 
 ### Load spec
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh spec`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh spec`
 
 ### Load plan
-!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh plan`
+Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh plan`
 
 ## Instructions
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -73,19 +73,41 @@ claude plugin list
 
 Expect `ai-development-framework@ai-development-framework` with `Status: ✔ enabled`. This writes `enabledPlugins` into `~/.claude/settings.json`, so the install is persistent and user-scoped: it applies to every project, with no flags.
 
-## Step 4 — Add the pre-flight permission rule (required in practice)
+## Step 4 — Add the helper permission rule (required in practice)
 
-Every spec-kit command begins with a pre-flight block that runs `speckit-helper.sh`. Without an allowlist entry, that call prompts — and in a non-interactive context it is **denied, which aborts the entire slash command silently: no error, no output**. A spec-kit command that appears to do nothing is almost always this.
+Most spec-kit commands gather live project data by running `speckit-helper.sh` with the Bash
+tool. Without an allowlist entry, every one of those calls prompts.
 
-Merge the following into `~/.claude/settings.json`, preserving everything already there. Substitute the real clone path; `$HOME` is expanded in permission rules, but `${CLAUDE_PLUGIN_ROOT}` is **not**, and a leading wildcard does **not** match — the path must be literal and absolute.
+Merge the following into `~/.claude/settings.json`, preserving everything already there.
+Substitute the real clone path — `$HOME` is expanded in permission rules, but
+`${CLAUDE_PLUGIN_ROOT}` is **not**, and a leading wildcard does **not** match, so the path
+must be literal and absolute.
 
 ```jsonc
 {
   "permissions": {
-    "allow": ["Bash($HOME/.claude-framework/.claude/hooks/speckit-helper.sh:*)"]
+    "allow": [
+      "Bash($HOME/.claude-framework//.claude/hooks/speckit-helper.sh:*)",
+      "Bash($HOME/.claude-framework/.claude/hooks/speckit-helper.sh:*)"
+    ]
   }
 }
 ```
+
+Both entries are deliberate, and the doubled slash in the first is not a typo.
+`${CLAUDE_PLUGIN_ROOT}` expands **with a trailing slash**, so the command
+`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh` reaches the permission matcher as
+`…/.claude-framework//.claude/hooks/…`. The matcher compares strings literally and does not
+normalise `//`, so a rule written with a single slash silently fails to match it. The second
+entry covers the case where a future release drops the trailing slash. Keep both.
+
+**Do not "fix" the commands by moving these calls back into a `` !`…` `` pre-execution
+block.** It does not work, and the failure is confusing: a `!` block is permission-checked
+*before* `${CLAUDE_PLUGIN_ROOT}` is substituted, so the checker sees a literal `${…}` and
+rejects the command with `Contains expansion` — no allowlist entry can match it, and
+`allowed-tools:` frontmatter does not help. `${CLAUDE_PROJECT_DIR}` *is* substituted before
+the check, but it points at the user's project, not the plugin. This has been shipped broken
+twice; the commands now instruct the model to run the helper with the Bash tool instead.
 
 Optional, only if the user wants Agent Teams (experimental, and it costs a full session per teammate — ask first, do not enable it silently):
 


### PR DESCRIPTION
## The bug

Every helper-backed command is dead on a plugin install. `/context`, `/quality`, `/pr-summary`, and the entire `/speckit.*` pipeline abort with:

```
Shell command permission check failed for pattern
"!`${CLAUDE_PLUGIN_ROOT}/.claude/hooks/speckit-helper.sh recent-commits`":
Contains expansion
```

**54 call sites across 15 commands.** This is not an install problem — it reproduces on a clean install done strictly by `SETUP.md`.

## Root cause

A `` !`…` `` pre-execution block is **permission-checked before `${CLAUDE_PLUGIN_ROOT}` is substituted**. The matcher sees a literal `${…}`, cannot predict what it expands to, and refuses. No allowlist entry can match such a pattern.

`aa32e83` introduced this while fixing a real bug — the commands had hardcoded `~/.claude/hooks/…`, correct under the old stow install but wrong under a plugin. It swapped a wrong-path bug for a can't-be-permitted bug, and nothing caught it because no slash command was run from a plugin install afterward.

## What I verified against the live permission checker

Not from the docs — the docs contradict themselves on which variables are substituted in skill content, and the `Contains expansion` error is undocumented. Each form was probed directly:

| Form | Result |
|---|---|
| `` !`${CLAUDE_PLUGIN_ROOT}/…` `` | rejected — `Contains expansion` |
| `` !`${CLAUDE_SKILL_DIR}/…` `` | rejected — identical failure |
| `` !`${CLAUDE_PLUGIN_ROOT}/…` `` + `allowed-tools:` frontmatter | rejected — frontmatter is irrelevant |
| `` !`${CLAUDE_PROJECT_DIR}/…` `` | **substituted** before the check — but points at the user's project, not the plugin |
| `${CLAUDE_PLUGIN_ROOT}` in **body text** | **substituted** to a literal absolute path |

So a `!` block can never name the plugin's own directory, and there is no documented pattern for a plugin slash command calling a script it ships.

## The fix

Body text *is* substituted. The 54 call sites now instruct the model to run the helper with the **Bash tool**, which receives an already-literal path. Each of the 15 files carries a short note explaining why, so this doesn't get "fixed" back into a `!` block a third time.

`SETUP.md` gains the matching allowlist rule — including a subtlety that cost real debugging time: **`${CLAUDE_PLUGIN_ROOT}` expands with a trailing slash**, so the command reaches the matcher as `…/.claude-framework//.claude/hooks/…`. The matcher compares literally and does **not** normalise `//`, so the single-slash rule in SETUP never matched it. Both forms are now listed.

## Verification

Confirmed end-to-end on a real plugin install, in a fresh session:

- `/context` runs. No permission error; the helper executes and returns live data (`recent-commits`, `branch`). `project-files` returns empty, which is correct — this repo has no `package.json`/`Cargo.toml`/`Makefile` to find.
- All 54 `!` blocks converted; none remain.
- Helper confirmed healthy at a literal path.

## Known limitation (not addressed here)

When a project ships its own `.claude/commands/context.md`, the **project-scope** copy shadows the plugin's — and a project-scope command gets no plugin root, so `${CLAUDE_PLUGIN_ROOT}` stays raw and the model has to already know the path. This only bites when working *inside this repo* (which is exactly where dogfooding happens). Deserves its own issue.

## Follow-up worth doing

Nothing tests the plugin's own commands. The last three commits are all packaging fixes — helper path, workflow, quality gate. A single smoke test that installs the plugin and runs `/context` would have caught this bug and probably the other two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)