### PR TITLE
fix: keep the anti-regression notes readable after substitution

### DIFF
--- a/commands/pr-summary.md
+++ b/commands/pr-summary.md
@@ -8,8 +8,10 @@ Generate a comprehensive pull request summary from the data below.
 
 ### Commits on this branch
 > The commands in this section must be run with the Bash tool; they cannot be
-> pre-executed in a `!` block. A `!` block is permission-checked before
-> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+> pre-executed in a `!` block. A `!` block is permission-checked before the
+> CLAUDE_PLUGIN_ROOT variable is substituted, so it is rejected as "Contains
+> expansion". Do not write that variable with a $ and braces here: it would be
+> substituted into this note and the warning would read as nonsense.
 
 Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/hooks/speckit-helper.sh pr-commits`
 

--- a/commands/project-context.md
+++ b/commands/project-context.md
@@ -18,8 +18,10 @@ For deep or repository-wide search, delegate to the built-in `Explore` agent rat
 
 ### Recent commits
 > The commands in this section must be run with the Bash tool; they cannot be
-> pre-executed in a `!` block. A `!` block is permission-checked before
-> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+> pre-executed in a `!` block. A `!` block is permission-checked before the
+> CLAUDE_PLUGIN_ROOT variable is substituted, so it is rejected as "Contains
+> expansion". Do not write that variable with a $ and braces here: it would be
+> substituted into this note and the warning would read as nonsense.
 
 Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/hooks/speckit-helper.sh recent-commits`
 

--- a/commands/speckit.analyze.md
+++ b/commands/speckit.analyze.md
@@ -10,8 +10,10 @@ Perform a read-only consistency analysis across all spec-kit artifacts for the c
 
 ### Current branch
 > The commands in this section must be run with the Bash tool; they cannot be
-> pre-executed in a `!` block. A `!` block is permission-checked before
-> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+> pre-executed in a `!` block. A `!` block is permission-checked before the
+> CLAUDE_PLUGIN_ROOT variable is substituted, so it is rejected as "Contains
+> expansion". Do not write that variable with a $ and braces here: it would be
+> substituted into this note and the warning would read as nonsense.
 
 Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/hooks/speckit-helper.sh branch`
 

--- a/commands/speckit.baseline.md
+++ b/commands/speckit.baseline.md
@@ -11,8 +11,10 @@ Reverse-engineer a specification from existing code in: **$ARGUMENTS**
 
 ### Current branch
 > The commands in this section must be run with the Bash tool; they cannot be
-> pre-executed in a `!` block. A `!` block is permission-checked before
-> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+> pre-executed in a `!` block. A `!` block is permission-checked before the
+> CLAUDE_PLUGIN_ROOT variable is substituted, so it is rejected as "Contains
+> expansion". Do not write that variable with a $ and braces here: it would be
+> substituted into this note and the warning would read as nonsense.
 
 Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/hooks/speckit-helper.sh branch`
 

--- a/commands/speckit.brainstorm.md
+++ b/commands/speckit.brainstorm.md
@@ -11,8 +11,10 @@ Explore and refine the idea before writing a formal spec: **$ARGUMENTS**
 
 ### Current branch
 > The commands in this section must be run with the Bash tool; they cannot be
-> pre-executed in a `!` block. A `!` block is permission-checked before
-> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+> pre-executed in a `!` block. A `!` block is permission-checked before the
+> CLAUDE_PLUGIN_ROOT variable is substituted, so it is rejected as "Contains
+> expansion". Do not write that variable with a $ and braces here: it would be
+> substituted into this note and the warning would read as nonsense.
 
 Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/hooks/speckit-helper.sh branch`
 

--- a/commands/speckit.checklist.md
+++ b/commands/speckit.checklist.md
@@ -10,8 +10,10 @@ Generate requirement quality checklists (NOT implementation tests) for the curre
 
 ### Current branch
 > The commands in this section must be run with the Bash tool; they cannot be
-> pre-executed in a `!` block. A `!` block is permission-checked before
-> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+> pre-executed in a `!` block. A `!` block is permission-checked before the
+> CLAUDE_PLUGIN_ROOT variable is substituted, so it is rejected as "Contains
+> expansion". Do not write that variable with a $ and braces here: it would be
+> substituted into this note and the warning would read as nonsense.
 
 Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/hooks/speckit-helper.sh branch`
 

--- a/commands/speckit.clarify.md
+++ b/commands/speckit.clarify.md
@@ -10,8 +10,10 @@ Scan the current branch's specification for ambiguities and generate targeted cl
 
 ### Current branch
 > The commands in this section must be run with the Bash tool; they cannot be
-> pre-executed in a `!` block. A `!` block is permission-checked before
-> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+> pre-executed in a `!` block. A `!` block is permission-checked before the
+> CLAUDE_PLUGIN_ROOT variable is substituted, so it is rejected as "Contains
+> expansion". Do not write that variable with a $ and braces here: it would be
+> substituted into this note and the warning would read as nonsense.
 
 Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/hooks/speckit-helper.sh branch`
 

--- a/commands/speckit.constitution.md
+++ b/commands/speckit.constitution.md
@@ -10,8 +10,10 @@ Create or update the project constitution at `.specify/memory/constitution.md`.
 
 ### Existing constitution
 > The commands in this section must be run with the Bash tool; they cannot be
-> pre-executed in a `!` block. A `!` block is permission-checked before
-> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+> pre-executed in a `!` block. A `!` block is permission-checked before the
+> CLAUDE_PLUGIN_ROOT variable is substituted, so it is rejected as "Contains
+> expansion". Do not write that variable with a $ and braces here: it would be
+> substituted into this note and the warning would read as nonsense.
 
 Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/hooks/speckit-helper.sh constitution`
 

--- a/commands/speckit.fix.md
+++ b/commands/speckit.fix.md
@@ -11,8 +11,10 @@ Apply a quick fix for: **$ARGUMENTS**
 
 ### Current branch
 > The commands in this section must be run with the Bash tool; they cannot be
-> pre-executed in a `!` block. A `!` block is permission-checked before
-> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+> pre-executed in a `!` block. A `!` block is permission-checked before the
+> CLAUDE_PLUGIN_ROOT variable is substituted, so it is rejected as "Contains
+> expansion". Do not write that variable with a $ and braces here: it would be
+> substituted into this note and the warning would read as nonsense.
 
 Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/hooks/speckit-helper.sh branch`
 

--- a/commands/speckit.implement.md
+++ b/commands/speckit.implement.md
@@ -10,8 +10,10 @@ Execute the implementation plan using strict TDD cycles with quality gates.
 
 ### Current branch
 > The commands in this section must be run with the Bash tool; they cannot be
-> pre-executed in a `!` block. A `!` block is permission-checked before
-> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+> pre-executed in a `!` block. A `!` block is permission-checked before the
+> CLAUDE_PLUGIN_ROOT variable is substituted, so it is rejected as "Contains
+> expansion". Do not write that variable with a $ and braces here: it would be
+> substituted into this note and the warning would read as nonsense.
 
 Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/hooks/speckit-helper.sh branch`
 

--- a/commands/speckit.init.md
+++ b/commands/speckit.init.md
@@ -10,8 +10,10 @@ Bootstrap a `.specify/` directory in the current project to enable spec-driven d
 
 ### Git root detection
 > The commands in this section must be run with the Bash tool; they cannot be
-> pre-executed in a `!` block. A `!` block is permission-checked before
-> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+> pre-executed in a `!` block. A `!` block is permission-checked before the
+> CLAUDE_PLUGIN_ROOT variable is substituted, so it is rejected as "Contains
+> expansion". Do not write that variable with a $ and braces here: it would be
+> substituted into this note and the warning would read as nonsense.
 
 Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/hooks/speckit-helper.sh check-git-root`
 

--- a/commands/speckit.plan.md
+++ b/commands/speckit.plan.md
@@ -10,8 +10,10 @@ Generate an implementation plan from the current branch's specification.
 
 ### Current branch
 > The commands in this section must be run with the Bash tool; they cannot be
-> pre-executed in a `!` block. A `!` block is permission-checked before
-> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+> pre-executed in a `!` block. A `!` block is permission-checked before the
+> CLAUDE_PLUGIN_ROOT variable is substituted, so it is rejected as "Contains
+> expansion". Do not write that variable with a $ and braces here: it would be
+> substituted into this note and the warning would read as nonsense.
 
 Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/hooks/speckit-helper.sh branch`
 

--- a/commands/speckit.review.md
+++ b/commands/speckit.review.md
@@ -10,8 +10,10 @@ Review the implementation plan before generating tasks.
 
 ### Current branch
 > The commands in this section must be run with the Bash tool; they cannot be
-> pre-executed in a `!` block. A `!` block is permission-checked before
-> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+> pre-executed in a `!` block. A `!` block is permission-checked before the
+> CLAUDE_PLUGIN_ROOT variable is substituted, so it is rejected as "Contains
+> expansion". Do not write that variable with a $ and braces here: it would be
+> substituted into this note and the warning would read as nonsense.
 
 Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/hooks/speckit-helper.sh branch`
 

--- a/commands/speckit.specify.md
+++ b/commands/speckit.specify.md
@@ -11,8 +11,10 @@ Generate a structured specification for: **$ARGUMENTS**
 
 ### Git status
 > The commands in this section must be run with the Bash tool; they cannot be
-> pre-executed in a `!` block. A `!` block is permission-checked before
-> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+> pre-executed in a `!` block. A `!` block is permission-checked before the
+> CLAUDE_PLUGIN_ROOT variable is substituted, so it is rejected as "Contains
+> expansion". Do not write that variable with a $ and braces here: it would be
+> substituted into this note and the warning would read as nonsense.
 
 Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/hooks/speckit-helper.sh branch`
 

--- a/commands/speckit.tasks.md
+++ b/commands/speckit.tasks.md
@@ -10,8 +10,10 @@ Generate a phased task list from the current branch's plan and specification.
 
 ### Current branch
 > The commands in this section must be run with the Bash tool; they cannot be
-> pre-executed in a `!` block. A `!` block is permission-checked before
-> `${CLAUDE_PLUGIN_ROOT}` is substituted, so it is rejected as "Contains expansion".
+> pre-executed in a `!` block. A `!` block is permission-checked before the
+> CLAUDE_PLUGIN_ROOT variable is substituted, so it is rejected as "Contains
+> expansion". Do not write that variable with a $ and braces here: it would be
+> substituted into this note and the warning would read as nonsense.
 
 Run with the Bash tool: `${CLAUDE_PLUGIN_ROOT}/hooks/speckit-helper.sh branch`
 

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -124,6 +124,16 @@ else
   ok "no command invokes the helper from a ! block"
 fi
 
+# The explanatory notes in those commands must survive substitution. They exist to stop the
+# `!` block being reintroduced a third time — but they are prose inside skill content, and
+# skill content is substituted. A note that spells the plugin-root variable with a $ and
+# braces gets its own warning replaced by a path, and reads as nonsense to the next reader.
+if grep -h '^>' "$REPO"/commands/*.md | grep -qF '${CLAUDE_PLUGIN_ROOT}'; then
+  bad "a note spells out the substitutable plugin-root variable — it will be replaced by a path and the warning will be gibberish"
+else
+  ok "the anti-regression notes survive substitution"
+fi
+
 # Every subcommand a command asks for must actually be implemented. A rename here fails
 # at runtime, inside a command, where nobody is watching.
 missing=0


### PR DESCRIPTION
The note in each of the 15 helper-backed commands explains why its calls cannot live in a `` !`…` `` block. It exists to stop that being reintroduced a third time (`aa32e83`, then #7).

But the note is **prose inside skill content, and skill content is substituted**. It spelled the plugin-root variable with a `$` and braces, so the harness replaced it with a path. Running `/project-context` renders the warning as:

> A `!` block is permission-checked before `/home/ariedi/.claude-framework/` is substituted, so it is rejected as "Contains expansion".

Nonsense. **The note was destroyed by the exact mechanism it was documenting** — and a maintainer reading that would learn nothing, which defeats the whole point of putting it there.

## Fix

Name the variable without the `$` so nothing can substitute it, and say plainly not to reintroduce the sigil:

> …permission-checked before the **CLAUDE_PLUGIN_ROOT** variable is substituted, so it is rejected as "Contains expansion". Do not write that variable with a `$` and braces here: it would be substituted into this note and the warning would read as nonsense.

A tier-1 check guards it — no note may contain the substitutable form. Mutation-tested: putting the sigil back turns the suite red.

## Verification

Smoke test green: 34/34 with the live tier, 31/31 tier-1 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)