### PR TITLE
docs: remove the dead stow install path; fix pipefail-blinded guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,17 +136,29 @@ claude plugin marketplace update ai-development-framework   # re-read the manife
 
 Restart Claude Code to pick up the new components. To check what changed first, read `CHANGELOG.md` in the clone.
 
-<details>
-<summary><b>Legacy: install via dotfiles + stow</b></summary>
+### 6️⃣ The two things the plugin cannot ship
 
-The original mechanism still works, but it cannot ship hooks — you must hand-write `settings.json`, and every new hook needs a manual edit.
+`plugin.json` ships **skills, commands, agents, hooks, workflows, and the MCP server**. There is no plugin component for **`rules/`** or **`CLAUDE.md`** — so installing the plugin does *not* give you the framework's global rules (code quality, git workflow, the Iron Laws, security, context management). If you want those to apply everywhere, copy them into `~/.claude/` yourself:
 
 ```bash
-git clone git@github.com:joaoariedi/dotfiles.git ~/dotfiles
-cd ~/dotfiles && stow claude    # symlinks CLAUDE.md, rules/, agents/, commands/, skills/, hooks/ into ~/.claude/
+cp -r ~/.claude-framework/.claude/rules ~/.claude/rules
+cp    ~/.claude-framework/.claude/CLAUDE.md ~/.claude/CLAUDE.md
 ```
 
-> ⚠️ **Do not use both.** Stowing the config *and* installing the plugin registers every skill, command, and agent **twice**. Pick one. Stow remains useful for `CLAUDE.md` and `rules/`, which are not plugin components — so if you want those globally, stow them and install the plugin only in projects that need it.
+> ⚠️ **These drift.** Nothing keeps them in sync — a `git pull` updates the plugin's components but not your copies. Re-copy them after an upgrade, and read `CHANGELOG.md` to see whether they changed. This is the one genuine gap in the plugin install, and it is a limitation of what a Claude Code plugin can contain, not an oversight.
+
+<details>
+<summary><b>Historical: the old dotfiles + stow install</b></summary>
+
+Before 4.4.0 the framework was installed by symlinking a dotfiles package into `~/.claude/` with GNU Stow. **That path is gone.** As of 4.5.0 the plugin payload lives at the repository root, not under `.claude/`, and the dotfiles package no longer carries `agents/`, `commands/`, `hooks/`, or `skills/` — following the old instructions today produces a half-install with none of them.
+
+If you have a legacy stow install, retire it before installing the plugin, or every component registers **twice**:
+
+```bash
+cd ~/dotfiles && stow -D claude    # then install the plugin as above
+```
+
+Keep `CLAUDE.md` and `rules/` if your dotfiles carry them — as above, the plugin cannot ship those.
 
 </details>
 
@@ -720,7 +732,7 @@ ai-assisted-development-framework/
 └── reports/                    # 11 research files: the "why" behind the rules
 ```
 
-> `CLAUDE.md` and `rules/` are **not** plugin components — a plugin cannot ship them. They apply when the repo is your project, or when you stow them globally. Everything else in the tree is shipped by `plugin.json`.
+> `CLAUDE.md` and `rules/` are **not** plugin components — a plugin cannot ship them. They apply when this repo *is* your project, or when you copy them into `~/.claude/` yourself (see *The two things the plugin cannot ship*). Everything else in the tree is shipped by `plugin.json`.
 
 ---
 

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -28,6 +28,16 @@ ok()   { printf '  \033[32mok\033[0m   %s\n' "$1"; PASS=$((PASS + 1)); }
 bad()  { printf '  \033[31mFAIL\033[0m %s\n' "$1"; FAIL=$((FAIL + 1)); }
 head_() { printf '\n\033[1m%s\033[0m\n' "$1"; }
 
+# NEVER write `producer | grep -q pattern` in this script.
+#
+# `set -o pipefail` is on, and `grep -q` exits the instant it matches. The producer then dies
+# with SIGPIPE (141), pipefail makes the PIPELINE return 141, and the `if` reads that as "no
+# match" — so a violating file reports as clean. Worse, it is a race: on a small input the
+# producer finishes before grep exits and the check works, which is how three guards in this
+# suite passed their own mutation tests while being unreliable.
+#
+# Capture first, match second: `x="$(producer)"` then `grep -q ... <<<"$x"`. No pipe, no race.
+
 # --- Tier 1: manifest ---------------------------------------------------------------
 head_ "Manifest"
 
@@ -128,7 +138,8 @@ fi
 # `!` block being reintroduced a third time — but they are prose inside skill content, and
 # skill content is substituted. A note that spells the plugin-root variable with a $ and
 # braces gets its own warning replaced by a path, and reads as nonsense to the next reader.
-if grep -h '^>' "$REPO"/commands/*.md | grep -qF '${CLAUDE_PLUGIN_ROOT}'; then
+notes="$(grep -h '^>' "$REPO"/commands/*.md || true)"
+if grep -qF '${CLAUDE_PLUGIN_ROOT}' <<<"$notes"; then
   bad "a note spells out the substitutable plugin-root variable — it will be replaced by a path and the warning will be gibberish"
 else
   ok "the anti-regression notes survive substitution"
@@ -163,12 +174,24 @@ head_ "Documented permission rule"
 # document $HOME and ~ as counter-examples ("❌ blocked"), in prose and tables, and flagging
 # those would be a false positive. Only a rule inside a code block is one a user will paste.
 for doc in SETUP.md README.md; do
-  if awk '/^```/{f=!f; next} f' "$REPO/$doc" | grep -qE 'Bash\((\$HOME|~)/[^)]*speckit-helper'; then
+  fenced="$(awk '/^```/{f=!f; next} f' "$REPO/$doc" || true)"
+  if grep -qE 'Bash\((\$HOME|~)/[^)]*speckit-helper' <<<"$fenced"; then
     bad "$doc prescribes a helper rule using \$HOME or ~ — neither is expanded, so it never matches"
   else
     ok "$doc prescribes a literal-path helper rule"
   fi
 done
+
+# The stow install is dead (#18) and must not be prescribed again. The payload no longer
+# lives under .claude/, and the dotfiles package no longer carries agents/commands/hooks/
+# skills — following those instructions yields a half-install with none of them. Only the
+# REMOVAL form (`stow -D claude`) is legitimate now.
+readme_fenced="$(awk '/^```/{f=!f; next} f' "$REPO/README.md" || true)"
+if grep -qE '(^|[^-])\bstow claude\b' <<<"$readme_fenced"; then
+  bad "README prescribes 'stow claude' as an install — that path is dead and yields a half-install (#18)"
+else
+  ok "README does not prescribe the dead stow install path"
+fi
 
 # --- Tier 1: helper runs ------------------------------------------------------------
 head_ "Helper"
@@ -220,7 +243,8 @@ if [ "${SMOKE_LIVE:-0}" = "1" ]; then
   claude plugin marketplace add "$REPO" >/dev/null 2>&1
   claude plugin install ai-development-framework@ai-development-framework >/dev/null 2>&1
 
-  if claude plugin list 2>/dev/null | grep -q 'ai-development-framework'; then
+  installed="$(claude plugin list 2>/dev/null || true)"
+  if grep -q 'ai-development-framework' <<<"$installed"; then
     ok "plugin installs into a clean config and reports enabled"
   else
     bad "plugin did not install"


### PR DESCRIPTION
Closes #18.

## The dead path

README documented dotfiles + GNU Stow as a supported legacy install. **It is dead.** The payload no longer lives under `.claude/` (#9), and the dotfiles package no longer carries `agents/`, `commands/`, `hooks/`, or `skills/`. Following those instructions today produces a half-install with none of them.

## What replaces it — and what was never stated

`plugin.json` ships skills, commands, agents, hooks, workflows, MCP. **There is no plugin component for `rules/` or `CLAUDE.md`.**

So installing the plugin does *not* give you the framework's global rules — code quality, git workflow, the Iron Laws, security, context management. You have to copy them yourself, and **they drift on every release**, because nothing keeps them in sync. That is a limitation of what a Claude Code plugin can contain, not an oversight, and users deserve to be told rather than left to discover it.

Stow *removal* instructions stay — legacy installs exist and must be retired before installing the plugin, or every component registers twice.

## The test bug this uncovered — three guards were unreliable

Building the guard for this issue exposed a real defect in the suite:

```bash
awk ... | grep -q PATTERN
```

`set -o pipefail` is on, and `grep -q` exits **the instant it matches**. The producer then dies with SIGPIPE (141), pipefail makes the **whole pipeline** return 141, and the `if` reads that as *no match* — **so a violating file reports clean.**

It's a race. On small input the producer finishes before grep exits and the check works. That is precisely how the `$HOME` guard (shipped in #20) and the note-substitution guard (#13) passed their own mutation tests **while being unreliable**. On a file the size of README, the new stow guard silently missed its own mutant — which is how I caught it.

All four sites now capture first and match second. Re-mutation-tested, and each now fails reliably:

| Mutant | Before | After |
|---|---|---|
| `stow claude` back in README | **missed** | ✅ caught |
| `$HOME` rule prescribed in SETUP | flaky (won the race) | ✅ caught |
| Substitutable token back in a note | flaky (won the race) | ✅ caught |

## Verification

Smoke: 35/35 tier-1, clean tree. Each mutation above turns it red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)