### PR TITLE
chore: release hygiene — version consistency check, tags, and a stated policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,36 @@
 
 All notable changes to the AI Development Framework will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) **from 4.5.0
+onward**: the next change that breaks an existing install — a renamed command, a moved path,
+a permission rule that must be edited — will be a **major** bump.
+
+It has not always. 4.5.0 itself renamed `/context` and moved the helper path under a *minor*
+bump, which semver does not permit. Saying so here is more useful than pretending otherwise;
+the breakage is flagged inline in that entry.
+
+Releases before 4.5.0 were never tagged. `v4.4.0` was applied retroactively to `6b02e5d`, the
+tip of `main` when 4.4.0 was current. Earlier versions have no identifiable release commit and
+are not tagged.
+
+## Releasing
+
+Six declarations of the version are bumped **by hand**, and `tests/smoke.sh` fails if they
+disagree — that check exists because nothing else would notice a half-bumped release:
+
+1. `.claude-plugin/plugin.json` → `version`
+2. `.claude-plugin/marketplace.json` → `metadata.version` **and** `plugins[0].version`
+3. `README.md` → the title and the **Framework Version** footer
+4. `.claude/CLAUDE.md` → the title
+5. Write the entry here, dated.
+6. `tests/smoke.sh` (and `SMOKE_LIVE=1` if you are logged in — it is the only check that
+   drives the plugin end to end).
+7. Tag it: `git tag -a vX.Y.Z && git push origin vX.Y.Z`, then cut a GitHub Release from the
+   entry above.
 
 ## [4.5.0] - 2026-07-13
 

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -60,6 +60,39 @@ while read -r agent; do
   else bad "agent $agent DOES NOT EXIST"; fi
 done < <(jq -r '.agents[]?' "$REPO/.claude-plugin/plugin.json")
 
+# --- Tier 1: version consistency ------------------------------------------------------
+head_ "Version"
+
+# Six places declare the version and every one is bumped BY HAND. A release that updates
+# plugin.json but forgets marketplace.json ships a plugin whose marketplace advertises the
+# old version — and nothing else notices. (#19)
+v_plugin="$(jq -r '.version' "$REPO/.claude-plugin/plugin.json")"
+v_mkt_meta="$(jq -r '.metadata.version' "$REPO/.claude-plugin/marketplace.json")"
+v_mkt_plug="$(jq -r '.plugins[0].version' "$REPO/.claude-plugin/marketplace.json")"
+v_readme="$(grep -oE 'Framework Version\*\*: [0-9]+\.[0-9]+\.[0-9]+' "$REPO/README.md" | grep -oE '[0-9.]+$')"
+v_changelog="$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' "$REPO/CHANGELOG.md" | tr -d '#[] ')"
+
+mismatch=0
+for pair in "marketplace.metadata:$v_mkt_meta" "marketplace.plugins[0]:$v_mkt_plug" \
+            "README footer:$v_readme" "CHANGELOG latest entry:$v_changelog"; do
+  where="${pair%%:*}"; val="${pair#*:}"
+  if [ "$val" != "$v_plugin" ]; then
+    bad "$where says $val but plugin.json says $v_plugin"
+    mismatch=$((mismatch + 1))
+  fi
+done
+
+# The two titles carry only major.minor.
+minor="${v_plugin%.*}"
+for f in README.md .claude/CLAUDE.md; do
+  t="$(grep -m1 -oE 'AI Development Framework v[0-9]+\.[0-9]+' "$REPO/$f" | grep -oE '[0-9.]+$')"
+  if [ "$t" != "$minor" ]; then
+    bad "$f title says v$t but plugin.json says $v_plugin"
+    mismatch=$((mismatch + 1))
+  fi
+done
+[ "$mismatch" -eq 0 ] && ok "all six version declarations agree ($v_plugin)"
+
 # --- Tier 1: the #9 regression guard ------------------------------------------------
 head_ "Payload location"
 


### PR DESCRIPTION
Closes #19.

## The problem

The repo carried **no tags at all**. Every version in `CHANGELOG.md` pointed at nothing: no way to check out what a user is actually running, no GitHub Releases, and "update with `git pull`" meant tracking `main` — including any half-finished state between merges.

## Tags

- **`v4.5.0`** tagged.
- **`v4.4.0`** applied retroactively to `6b02e5d` — the tip of `main` when 4.4.0 was current, verified to carry `version: 4.4.0`. Its annotation warns that on a plugin install every helper-backed command is dead at that commit (fixed in 4.5.0).
- Earlier versions have **no identifiable release commit** and are left untagged rather than guessed at. The 4.4.0 entry itself records that `v4.3.1` was "a working marker rather than a cut release."

## Version consistency check (tier 1)

**Six** declarations of the version are bumped **by hand**:

| | |
|---|---|
| `plugin.json` | `version` |
| `marketplace.json` | `metadata.version` **and** `plugins[0].version` |
| `README.md` | the title **and** the Framework Version footer |
| `.claude/CLAUDE.md` | the title |

A release that bumps one and forgets another ships a plugin whose marketplace advertises the old version — and nothing notices. The suite now fails if they disagree.

Mutation-tested: bumping `plugin.json` alone flags all six.

## Versioning policy — stated honestly

The CHANGELOG claimed "this project adheres to Semantic Versioning." It does not. **4.5.0 renamed `/context` and moved the helper path under a *minor* bump**, which semver does not permit.

Rather than quietly keep the claim, the preamble now says: semver applies **from 4.5.0 onward** — the next change that breaks an existing install is a **major** bump — and records that 4.5.0 itself violated it. That is more useful to a reader than a badge the project doesn't earn.

If you'd rather adopt a different policy (e.g. "breaking changes are allowed in minors until 5.0"), this is the place to change it — it's a one-paragraph edit and I've deliberately left it as a statement of fact rather than a decision I made for you.

## Also

Added a release checklist, since the six-file hand-bump is the step most likely to be done wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)