### PR TITLE
fix: distinguish "no tests exist" from "could not detect them" (#31)

### DIFF
--- a/tests/workflow.test.js
+++ b/tests/workflow.test.js
@@ -145,7 +145,7 @@ export async function drive({ canned, parallel = parallelThrowToNull, args = { f
 
 /** Build a `load-artifacts` payload. */
 export const graph = (phases, extra = {}) => ({
-  featureDir: '/f', projectRoot: '/r', testCommand: 'pytest', phases, ...extra,
+  featureDir: '/f', projectRoot: '/r', testCommand: 'pytest', testCommandStatus: 'detected', phases, ...extra,
 })
 
 export const task = (id, o = {}) => ({
@@ -428,6 +428,124 @@ test('SC-005 + SC-013 + SC-017: the ledger balances and is not fooled by a dupli
     `BALANCE: accepted+rejected+notAttempted must equal total; got ${sum} vs ${result.total} — ` +
     `a task vanished. Keying on the model-authored id does exactly this.`)
   assert.deepEqual(result.notAttempted, ['T001'], "phase 2's T001 was never attempted and must say so")
+})
+
+// =============================================================================================
+// #31 — `testCommand: ""` conflated "this project has no tests" with "I could not detect them".
+//
+// Nothing distinguished them, and every consumer treated the second as the first: implementers
+// could not confirm RED/GREEN, the lens had no suite, and the gate was TOLD to report passed:true
+// for a project with no gate — so a DETECTION FAILURE produced a clean N/N run that verified
+// nothing. This repo is that case: its suite is tests/smoke.sh, and the loader was told to look
+// only for package.json/pytest/cargo/go.
+// =============================================================================================
+
+test('#31: an UNDETECTABLE test command halts at load — before any work is spawned', async () => {
+  const g = graph([{ name: 'Phase 1', tasks: [task('T001')] }],
+    { testCommand: '', testCommandStatus: 'undetectable' })
+  const { result, spawned } = await drive({ canned: baseCanned(g) })
+  // Nothing downstream can verify anything, so refuse to start rather than burn a full run and
+  // report clean. The file's own bias: a task wrongly refused costs one round; wrongly accepted
+  // ships a bug.
+  assert.ok(result.halted, `must halt; got ${JSON.stringify(result)}`)
+  assert.equal(result.haltedAt, 'Load')
+  assert.match(result.reason, /could not|undetectable|args\.testCommand/i,
+    'the reason must name the remedy — the operator has to know to pass args.testCommand')
+  assert.deepEqual(spawned, ['load-artifacts'], 'NO implementer may spawn — that is the point of halting at load')
+})
+
+test('#31: a project that genuinely has NO tests still runs — absence is not failure', async () => {
+  const g = graph([{ name: 'Phase 1', tasks: [task('T001')] }],
+    { testCommand: '', testCommandStatus: 'none-exist' })
+  const { result, spawned } = await drive({ canned: baseCanned(g) })
+  // The carve-out is CORRECT for the case it was written for. Halting over a project that never
+  // had tests would be a false alarm — this is the regression guard for that.
+  assert.ok(!result.halted, `a genuinely test-less project must still run; got ${JSON.stringify(result)}`)
+  assert.equal(result.completed, 1)
+  assert.ok(spawned.includes('gate:Phase 1'), 'the gate still runs — it just has no suite to assert')
+})
+
+test('#31: the gate is not asked to run a suite that does not exist', async () => {
+  const g = graph([{ name: 'Phase 1', tasks: [task('T001')] }],
+    { testCommand: '', testCommandStatus: 'none-exist' })
+  let gatePrompt = ''
+  const { } = await drive({
+    canned: withOverrides(baseCanned(g), [
+      ['gate:Phase 1', () => ({ passed: true, summary: 'no suite' })],
+    ]),
+    // capture the prompt the gate actually receives
+    args: { featureDir: '/f' },
+  })
+  // Re-drive capturing the prompt text (the stub kit records labels, not prompts).
+  const kit = makeAgentStub(baseCanned(g))
+  const agent = async (p, o = {}) => { if (o.label?.startsWith('gate:')) gatePrompt = p; return kit.agent(p, o) }
+  await makeRun(loadWorkflowSource())(agent, parallelThrowToNull, () => {}, () => {}, { featureDir: '/f' })
+  assert.ok(!/Full test suite.*must be green/i.test(gatePrompt),
+    'with no suite in existence the gate must NOT be told "Full test suite — must be green" with no command')
+  assert.match(gatePrompt, /no automated test suite|has no tests/i,
+    'the gate must be told plainly that this project has no suite')
+  // The loader must not grade its own homework. "none-exist" is the one status that silently disables
+  // every verification gate, and it is model-authored — so the gate agent, which is a DIFFERENT agent
+  // standing in the repo, is told to refute it. A prompt asking the model nicely is not a mechanism;
+  // an independent agent that can say "I found tests/" is.
+  assert.match(gatePrompt, /CHECK THAT CLAIM|claim is false/i,
+    'the gate must be told to REFUTE the no-tests claim, not take the loader\'s word for it')
+  assert.match(gatePrompt, /passed:false/,
+    'the gate must know what to do when it finds tests the loader missed')
+})
+
+test('#31: args.testCommand overrides detection and makes an otherwise-undetectable repo runnable', async () => {
+  // Without this, halt-on-undetectable has no remedy but editing the workflow. With it, THIS repo
+  // can run its own workflow: args.testCommand = 'tests/smoke.sh'.
+  const g = graph([{ name: 'Phase 1', tasks: [task('T001')] }],
+    { testCommand: '', testCommandStatus: 'undetectable' })
+  let gatePrompt = ''
+  const kit = makeAgentStub(baseCanned(g))
+  const agent = async (p, o = {}) => { if (o.label?.startsWith('gate:')) gatePrompt = p; return kit.agent(p, o) }
+  const result = await makeRun(loadWorkflowSource())(
+    agent, parallelThrowToNull, () => {}, () => {}, { featureDir: '/f', testCommand: 'tests/smoke.sh' })
+  assert.ok(!result.halted, `an explicit testCommand must override an undetectable status; got ${JSON.stringify(result)}`)
+  assert.match(gatePrompt, /tests\/smoke\.sh/, 'the gate must be given the operator-supplied command')
+})
+
+test('#31: a non-string or empty args.testCommand is rejected, not silently honoured', async () => {
+  // A had no argument surface until now, so it inherits #29's lesson the moment it gains one:
+  // `args` can arrive as a JSON blob, and a value that is not a usable command must not silently
+  // become one. "" must not mean "detected an empty command".
+  for (const bad of ['', '   ', 42, null, {}]) {
+    const g = graph([{ name: 'Phase 1', tasks: [task('T001')] }],
+      { testCommand: '', testCommandStatus: 'undetectable' })
+    const result = await makeRun(loadWorkflowSource())(
+      makeAgentStub(baseCanned(g)).agent, parallelThrowToNull, () => {}, () => {},
+      { featureDir: '/f', testCommand: bad })
+    assert.ok(result.halted,
+      `args.testCommand=${JSON.stringify(bad)} is not a usable command and must NOT override the undetectable halt`)
+  }
+})
+
+test('#31: an unrecognised testCommandStatus is treated as undetectable, never as fine', async () => {
+  // The status is model-authored, so the model can return something outside the enum — a typo, a
+  // hallucinated fourth state, or nothing at all if an older loader payload is replayed from cache.
+  // The safe reading of a value we do not understand is "we do not know", never "everything is fine".
+  // That is the whole of #31 in one line, so it gets a test: without one, deleting the fallback goes
+  // unnoticed (verified — the mutation was green until this existed).
+  for (const status of ['DETECTED', 'maybe', '', undefined, null, 42]) {
+    const g = graph([{ name: 'Phase 1', tasks: [task('T001')] }],
+      { testCommand: '', testCommandStatus: status })
+    const { result } = await drive({ canned: baseCanned(g) })
+    assert.ok(result.halted,
+      `testCommandStatus=${JSON.stringify(status)} is not a status we understand and must halt, not proceed`)
+    assert.equal(result.haltedAt, 'Load')
+  }
+})
+
+test('#31: an incoherent loader answer (detected + empty command) is treated as undetectable', async () => {
+  // The status is model-authored. `detected` with no command is self-contradictory, and this file
+  // does not trust model-authored fields it can check — the [P] marker sets that precedent.
+  const g = graph([{ name: 'Phase 1', tasks: [task('T001')] }],
+    { testCommand: '', testCommandStatus: 'detected' })
+  const { result } = await drive({ canned: baseCanned(g) })
+  assert.ok(result.halted, 'a "detected" status with no command must not be believed')
 })
 
 test('SC-017: a done:true task is excluded from total, and an unreached phase is notAttempted', async () => {

--- a/workflows/speckit-workflow.js
+++ b/workflows/speckit-workflow.js
@@ -37,7 +37,21 @@ const TASKS_SCHEMA = {
       description:
         'Absolute path to the repo that OWNS this feature — the directory containing .specify/. Every agent must run commands here. It is NOT necessarily the session cwd.',
     },
-    testCommand: { type: 'string', description: 'command that runs the full suite; empty if none detected' },
+    testCommand: { type: 'string', description: 'the command that runs the full suite. Empty unless testCommandStatus is "detected".' },
+    // `""` used to mean BOTH "this project has no tests" and "I could not find them", and every
+    // consumer downstream treated the second as the first — so a detection failure produced a run
+    // that reported N/N clean while verifying nothing. These are different facts and the schema now
+    // forces the loader to say which one it means.
+    testCommandStatus: {
+      type: 'string',
+      enum: ['detected', 'none-exist', 'undetectable'],
+      description:
+        '"detected": you found the command and put it in testCommand. ' +
+        '"none-exist": you looked and this project genuinely has NO automated tests at all. ' +
+        '"undetectable": tests plainly EXIST but you could not determine the command to run them. ' +
+        'Never guess between the last two: "none-exist" makes the run proceed without mechanical ' +
+        'verification, so claiming it about a project that has tests silently disables every gate.',
+    },
     phases: {
       type: 'array',
       items: {
@@ -296,8 +310,22 @@ Resolve projectRoot: the directory that CONTAINS .specify/ (i.e. the feature dir
 feature belongs to and it may NOT be the session's working directory — every later agent
 runs its commands there.
 
-Detect the command that runs the full test suite by looking in projectRoot (package.json
-scripts.test, pytest, cargo test, go test ./...). Return "" if there is none.
+Detect the command that runs the full test suite, by looking in projectRoot for whatever this
+project actually uses — NOT only the obvious ecosystems. Check: package.json scripts.test,
+pytest/tox, cargo test, go test ./..., but ALSO a Makefile target, a shell script under tests/ or
+scripts/, the commands a CI workflow runs, and anything the README or CONTRIBUTING names as the way
+to run tests. A project whose suite is a shell script is a project with tests.
+
+Then report testCommandStatus, and be precise, because the three answers route very differently:
+  - "detected"     — you found it. Put the command in testCommand.
+  - "none-exist"   — you looked properly and this project has NO automated tests at all. The run
+                     will then proceed WITHOUT mechanical verification.
+  - "undetectable" — tests clearly exist but you cannot name the command. The run will HALT and ask
+                     the operator for it.
+
+Do not report "none-exist" because the search was hard. Absence of tests is a strong claim: it turns
+off every verification gate in this workflow. If you can see test files, test directories, or a CI
+job running tests, then tests exist — say "undetectable" and let a human supply the command.
 
 Report tasks in the order they appear. Do not invent, reorder, or merge tasks.`,
   { schema: TASKS_SCHEMA, label: 'load-artifacts' },
@@ -314,8 +342,62 @@ ctx.phases.forEach((p, pi) => p.tasks.forEach((t, ti) => { t._key = keyOf(pi, ti
 
 const pending = ctx.phases.flatMap(p => p.tasks.filter(t => !t.done))
 log(`${ctx.featureDir}: ${pending.length} pending task(s) across ${ctx.phases.length} phase(s)`)
-if (!ctx.testCommand) {
-  log('WARNING: no test command detected. TDD cycles cannot be mechanically confirmed.')
+
+// --- the test command: three states, three fates -------------------------------------------------
+//
+// `""` used to mean both "no tests exist" and "detection failed", and this site WARNED AND PROCEEDED
+// on either. The warning is precisely why nobody noticed: a detection failure sailed past it, the
+// gate was then told to report passed:true for a project with no gate, and the run finished N/N clean
+// having verified nothing. THIS repo was that case — its suite is tests/smoke.sh, and the loader was
+// told to look only for package.json/pytest/cargo/go.
+//
+// An operator-supplied command wins outright: it is a fact, not an inference. Validate it, because
+// `args` can arrive as a JSON blob (see the normalisation above) and a value that is not a usable
+// command must not silently become one — "" must never mean "detected an empty command".
+const argTest = typeof _args?.testCommand === 'string' ? _args.testCommand.trim() : ''
+if (_args?.testCommand !== undefined && !argTest) {
+  log(`ignoring args.testCommand: ${JSON.stringify(_args.testCommand)} is not a usable command`)
+}
+if (argTest) {
+  ctx.testCommand = argTest
+  ctx.testCommandStatus = 'detected'
+  log(`test command supplied by the operator: ${argTest}`)
+}
+
+// The status is model-authored, so check what can be checked. "detected" with no command is
+// self-contradictory; this file already refuses to trust the model-written [P] marker on the same
+// grounds. An unrecognised status is treated as undetectable for the same reason: the safe reading of
+// a value we do not understand is "we do not know", never "everything is fine".
+if (ctx.testCommandStatus === 'detected' && !ctx.testCommand) {
+  ctx.testCommandStatus = 'undetectable'
+}
+if (!['detected', 'none-exist', 'undetectable'].includes(ctx.testCommandStatus)) {
+  ctx.testCommandStatus = 'undetectable'
+}
+
+if (ctx.testCommandStatus === 'undetectable') {
+  // Halt BEFORE spawning anything. Nothing downstream can verify a thing: implementers cannot confirm
+  // RED or GREEN, the task-test lens has no suite to run, and the gate cannot honestly pass. Refusing
+  // costs the operator one re-run with args.testCommand; proceeding costs a full run that reports
+  // clean while checking nothing. A task wrongly refused costs one round; wrongly accepted ships a bug.
+  log('HALTED at Load: tests exist but the command to run them is unknown')
+  return {
+    halted: true,
+    haltedAt: 'Load',
+    reason:
+      `Tests exist in ${ctx.projectRoot} but the loader could not determine the command that runs them, ` +
+      'so nothing in this run could be mechanically verified — every gate would pass vacuously and the ' +
+      'run would report success having checked nothing. Re-run with an explicit command, e.g. ' +
+      'args.testCommand = "tests/smoke.sh".',
+    ...ledger([], ctx),
+  }
+}
+
+if (ctx.testCommandStatus === 'none-exist') {
+  // The carve-out is correct for the case it was written for: halting over a project that never had
+  // tests would be a false alarm. It is only wrong when a DETECTION FAILURE is routed here, which the
+  // status now prevents.
+  log('this project has no automated tests — proceeding without mechanical verification of TDD cycles')
 }
 
 async function implementAndVerify(task) {
@@ -424,13 +506,27 @@ for (const ph of ctx.phases) {
 FIRST: cd ${ctx.projectRoot}. That is the repo under test. It is NOT necessarily your shell's
 starting directory, and running these commands anywhere else tells you nothing.
 
-  1. Full test suite${ctx.testCommand ? ` (\`${ctx.testCommand}\`)` : ''} — must be green.
-  2. Lint / format / typecheck, whichever that project configures.
+${
+      ctx.testCommandStatus === 'none-exist'
+        ? `  1. The loader reported that this project has NO automated test suite, so there is no suite to run.
+     CHECK THAT CLAIM before you accept it. You are standing in the repo and the loader is not; it is
+     a different agent and it may simply have failed to find the tests. Look for test files, a tests/
+     directory, a Makefile test target, a test script, a CI job that runs tests. If you find ANY of
+     them, the claim is false — report passed:false, name what you found, and say the command could
+     not be determined. Do NOT run a suite you discover: reporting the discovery is the job here.
+  2. Lint / format / typecheck, whichever that project configures.`
+        : `  1. Full test suite (\`${ctx.testCommand}\`) — must be green. Run exactly that command.
+  2. Lint / format / typecheck, whichever that project configures.`
+    }
 
 Show real command output. Do not fix anything; only report.
-"passed" means you SAW the suite pass. If the project configures no gate at all, that is an
+"passed" means you SAW the gate pass. If the project configures no gate at all, that is an
 ABSENCE of a gate, not a failure — report passed:true and say so in the summary, because
-halting the run over a project that never had tests would be a false alarm.`,
+halting the run over a project that never had tests would be a false alarm.
+
+That carve-out is about a project that HAS no gate. It is not licence to report passed:true because
+a command was missing, unclear, or inconvenient — if you cannot run what you were asked to run, say
+so and report passed:false.`,
     { label: `gate:${ph.name}`, phase: 'Implement', schema: GATE_SCHEMA },
   )
 


### PR DESCRIPTION
Fixes #31.

`testCommand: ""` meant **two different things** — *"this project has no tests"* and *"I couldn't find them"* — and every consumer downstream read the second as the first.

A **detection failure** therefore produced: implementers that couldn't confirm RED or GREEN, a lens with no suite to run, a phase gate *explicitly told* to report `passed:true` for a project with no gate, and a run that finished **N/N clean having verified nothing**.

## This repo was that case

Its suite is `tests/smoke.sh`. The loader was told to look only for `package.json`/`pytest`/`cargo`/`go` — so **the prompt manufactured the false negative** and the empty string discarded the distinction. Running `speckit-workflow` on the framework itself silently disabled every gate it exists to enforce.

## Three bugs, not one

| | |
|---|---|
| **Detection was a fixed list of four ecosystems** | Now looks for what a project *actually* uses: Makefile targets, shell scripts under `tests/`, what CI runs, what the README says. A project whose suite is a shell script is a project with tests. |
| **The status was implicit** | Now schema-forced: `detected` \| `none-exist` \| `undetectable`. Two different facts can no longer be spelled the same way. |
| **They routed identically** | `undetectable` now **halts at load**, before spawning anything. `none-exist` keeps the carve-out, which was always correct for the case it was written for. |

Halting at load rather than later: nothing downstream could verify a thing, so refusing costs the operator one re-run while proceeding costs a full run that lies. The file's own bias — *a task wrongly refused costs one round; wrongly accepted ships a bug*.

## `args.testCommand`

Overrides detection outright — it's a fact, not an inference. **Validated**, because A had no argument surface until now and inherits #29's lesson the moment it gains one: `args` can arrive as a JSON blob, and `""` must never mean "detected an empty command".

This is also what makes this repo runnable: `args.testCommand = "tests/smoke.sh"`.

## The loader does not grade its own homework

The status is model-authored, so what can be checked is checked: `detected` with no command is self-contradictory; an unrecognised status is treated as *unknown*, never as *fine*. This file already refuses to trust the model-written `[P]` marker.

But the residual hole mattered: a model that claims `none-exist` about a repo with tests still switches off every gate, and **"we asked the model nicely" is not a mechanism** — this file exists because a script guarantees the barrier where a model talks itself past it.

So the **gate agent — a different agent, standing in the repo — is told to refute the claim**: if it can see test files, a `tests/` directory, a Makefile target, or a CI job running tests, the claim is false → `passed:false`. An independent agent that can say *"I found tests/"* is a mechanism.

## Verification

```
node --test      25 pass, 0 fail   (7 new, all RED against the unmodified file first)
tests/smoke.sh   44 passed, 0 failed
spawns           1 (choke point holds)
code             435 lines (limit 500)
```

**Every mutation executed, not asserted.** One initially stayed green and exposed a real gap — the unrecognised-status fallback had no test, so deleting it went unnoticed. That test now exists. A second mutation was too weak (it removed one branch of an alternation) and proved nothing until redone in full.

End-to-end, driving the shipped file:

```
undetectable          -> halts at Load. 1 agent ran. Reason names the remedy.
+ args.testCommand    -> runs. Gate told to run: tests/smoke.sh
none-exist            -> runs. Gate told to REFUTE the no-tests claim.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)