### PR TITLE
fix: read the Iron Law's own evidence instead of discarding it (#32)

### DIFF
--- a/tests/workflow.test.js
+++ b/tests/workflow.test.js
@@ -156,7 +156,7 @@ export const task = (id, o = {}) => ({
 /** Default happy answers for every label the workflow spawns. */
 export const baseCanned = (loadPayload) => (label) => {
   if (label === 'load-artifacts') return loadPayload
-  if (label.startsWith('impl:')) return { id: label.slice(5), succeeded: true, summary: 's', redConfirmed: true, greenConfirmed: true }
+  if (label.startsWith('impl:')) return { id: label.slice(5), succeeded: true, summary: 's', tddStatus: 'cycle-confirmed', redConfirmed: true, greenConfirmed: true }
   if (label.startsWith('verify:')) return { refuted: false, reason: 'ok' }
   if (label.startsWith('gate:')) return { passed: true, summary: 'green' }
   return 'report text'
@@ -546,6 +546,125 @@ test('#31: an incoherent loader answer (detected + empty command) is treated as 
     { testCommand: '', testCommandStatus: 'detected' })
   const { result } = await drive({ canned: baseCanned(g) })
   assert.ok(result.halted, 'a "detected" status with no command must not be believed')
+})
+
+// =============================================================================================
+// #32 — the Iron Law's own evidence was collected and thrown away.
+//
+// The implementer was asked to report redConfirmed/greenConfirmed "based on output you actually
+// observed, not intent". Those fields were declared in the schema, rendered into the verifier's
+// prompt, and read by NO CODE — zero conditionals. So an implementer reporting redConfirmed:false,
+// openly admitting the test never failed first, was accepted exactly like one that ran the full
+// cycle. The only mitigation was that a verifier MIGHT refute on the prose — model judgment, in a
+// file whose founding thesis is that a script guarantees the barrier because a model can talk
+// itself past it.
+//
+// Not every task has a RED phase: this repo's own T012 was "bump the version in six files". So the
+// implementer DECLARES tddStatus and a different agent REFUTES a false claim — the #31 pattern.
+// =============================================================================================
+
+const implSays = (over) => (label) =>
+  label.startsWith('impl:') ? { id: label.slice(5), succeeded: true, summary: 's', ...over } : undefined
+
+/** baseCanned, with the impl payload replaced. */
+const withImpl = (g, over) => (label, opts) => implSays(over)(label) ?? baseCanned(g)(label, opts)
+
+test('#32: an implementer that admits the test never failed first is NOT accepted', async () => {
+  const g = FIXTURES.twoPhasesSequential()
+  const { result } = await drive({
+    canned: withImpl(g, { tddStatus: 'cycle-confirmed', redConfirmed: false, greenConfirmed: true }),
+  })
+  // redConfirmed:false IS the admission that the test may assert nothing — which the test-integrity
+  // lens calls "the single most common way an agent fakes completion". It was accepted anyway.
+  assert.ok(result.halted, `must not accept an unconfirmed RED; got ${JSON.stringify(result)}`)
+  assert.match(JSON.stringify(result.rejected), /red|never observed failing|TDD/i,
+    'the rejection must name the missing RED evidence')
+})
+
+test('#32: omitting the evidence entirely is not acceptance either', async () => {
+  const g = FIXTURES.twoPhasesSequential()
+  const { result } = await drive({ canned: withImpl(g, { tddStatus: 'cycle-confirmed' }) })
+  // `undefined` rendered into the verifier's prompt as the literal text "red confirmed: undefined".
+  // Absence of evidence is not evidence.
+  assert.ok(result.halted, 'claiming cycle-confirmed while reporting no red/green must not be accepted')
+})
+
+test('#32: greenConfirmed is required too, not just red', async () => {
+  const g = FIXTURES.twoPhasesSequential()
+  const { result } = await drive({
+    canned: withImpl(g, { tddStatus: 'cycle-confirmed', redConfirmed: true, greenConfirmed: false }),
+  })
+  assert.ok(result.halted, 'a cycle is not confirmed until the test was seen to PASS as well')
+})
+
+test('#32: a task with no RED phase still runs, if the implementer says why', async () => {
+  // The regression guard that keeps this usable. This repo's own tasks.md is full of these: the
+  // version bump, the CI step, the CHANGELOG. Strict enforcement would halt on all of them and
+  // someone would rightly rip the check out.
+  const g = FIXTURES.twoPhasesSequential()
+  const { result } = await drive({
+    canned: withImpl(g, { tddStatus: 'not-applicable', tddNotApplicableReason: 'bumps a version string in six files; there is no behaviour to test' }),
+  })
+  assert.ok(!result.halted, `a declared non-TDD task must still run; got ${JSON.stringify(result)}`)
+  assert.equal(result.completed, 2)
+})
+
+test('#32: "not applicable" without a reason is not a declaration, it is an escape hatch', async () => {
+  const g = FIXTURES.twoPhasesSequential()
+  const { result } = await drive({ canned: withImpl(g, { tddStatus: 'not-applicable' }) })
+  // Without this, `not-applicable` is a free pass any implementer can claim — the check would exist
+  // and enforce nothing.
+  assert.ok(result.halted, 'an unexplained not-applicable must not be accepted')
+})
+
+test('#32: an unrecognised tddStatus is unverified, never fine', async () => {
+  const g = FIXTURES.twoPhasesSequential()
+  for (const s of ['confirmed', '', undefined, null, true]) {
+    const { result } = await drive({ canned: withImpl(g, { tddStatus: s, redConfirmed: true, greenConfirmed: true }) })
+    assert.ok(result.halted, `tddStatus=${JSON.stringify(s)} is not a status we understand and must not be accepted`)
+  }
+})
+
+test('#32: a project with NO test suite cannot be asked for a cycle it could never observe', async () => {
+  // The #31 interaction. With no suite, RED/GREEN are unobservable by construction — demanding them
+  // would halt every test-less project, which is the false alarm #31's carve-out exists to prevent.
+  const g = graph([{ name: 'Phase 1', tasks: [task('T001')] }],
+    { testCommand: '', testCommandStatus: 'none-exist' })
+  const { result } = await drive({ canned: withImpl(g, { tddStatus: 'cycle-confirmed', redConfirmed: false }) })
+  assert.ok(!result.halted, `a test-less project must not be held to TDD evidence; got ${JSON.stringify(result)}`)
+})
+
+test('#32: a task rejected on TDD evidence does not spawn three verifiers', async () => {
+  const g = FIXTURES.twoPhasesSequential()
+  const { spawned } = await drive({
+    canned: withImpl(g, { tddStatus: 'cycle-confirmed', redConfirmed: false }),
+  })
+  // Reject before the fan-out: there is nothing for three agents to adversarially verify about work
+  // that already failed its own evidence check. This thing already spawns too many agents (#29).
+  assert.ok(!spawned.some(l => l.startsWith('verify:')),
+    `no verifier should spawn for an already-rejected task; got ${spawned.join(', ')}`)
+})
+
+test('#32: the test-integrity lens is told to refute a FALSE not-applicable claim', async () => {
+  const g = FIXTURES.twoPhasesSequential()
+  let lensPrompt = ''
+  const kit = makeAgentStub(withImpl(g, { tddStatus: 'not-applicable', tddNotApplicableReason: 'nah' }))
+  const agent = async (p, o = {}) => { if (o.label?.includes('test-integrity')) lensPrompt = p; return kit.agent(p, o) }
+  await makeRun(loadWorkflowSource())(agent, parallelThrowToNull, () => {}, () => {}, { featureDir: '/f' })
+  // The implementer must not grade its own homework. `not-applicable` is the one status that skips
+  // the evidence check, so the lens that already reads the test diff is told to contradict it.
+  //
+  // Assert on text UNIQUE to the cross-check. The obvious assertions — /not-applicable/ and /refute/ —
+  // both pass with the cross-check deleted: the base lens already says "Refute if: the assertion was
+  // loosened", and verifyPrompt itself renders "claims NO test was needed". Matching those proves the
+  // prompt exists, not that the cross-check does. Verified: with the loose assertions, removing the
+  // whole block left this test green.
+  assert.match(lensPrompt, /CHECK THAT CLAIM/,
+    'the lens must be told to check the not-applicable claim, not just to look for weakened tests')
+  assert.match(lensPrompt, /the claim is FALSE/,
+    'the lens must be told what to conclude when the reason does not hold up')
+  assert.match(lensPrompt, /version bump|config edit|docs change/i,
+    'the lens needs the line between a genuine exemption and an inconvenient test')
 })
 
 test('SC-017: a done:true task is excluded from total, and an unreached phase is notAttempted', async () => {

--- a/workflows/speckit-workflow.js
+++ b/workflows/speckit-workflow.js
@@ -82,7 +82,11 @@ const TASKS_SCHEMA = {
 
 const IMPL_SCHEMA = {
   type: 'object',
-  required: ['id', 'succeeded', 'summary'],
+  // `tddStatus` is REQUIRED. redConfirmed/greenConfirmed were optional, so an implementer could simply
+  // omit the Iron Law's evidence and be accepted — and they were read by no code anyway. Requiring the
+  // status means the harness re-asks an implementer that leaves it out, instead of the workflow
+  // quietly deciding that silence means yes.
+  required: ['id', 'succeeded', 'summary', 'tddStatus'],
   properties: {
     id: { type: 'string' },
     succeeded: { type: 'boolean' },
@@ -90,8 +94,22 @@ const IMPL_SCHEMA = {
     testFile: { type: 'string' },
     testName: { type: 'string' },
     filesChanged: { type: 'array', items: { type: 'string' } },
-    redConfirmed: { type: 'boolean', description: 'the test was observed FAILING before the implementation existed' },
-    greenConfirmed: { type: 'boolean', description: 'the test was observed PASSING afterwards' },
+    redConfirmed: { type: 'boolean', description: 'the test was observed FAILING before the implementation existed. Required when tddStatus is "cycle-confirmed".' },
+    greenConfirmed: { type: 'boolean', description: 'the test was observed PASSING afterwards. Required when tddStatus is "cycle-confirmed".' },
+    tddStatus: {
+      type: 'string',
+      enum: ['cycle-confirmed', 'not-applicable'],
+      description:
+        '"cycle-confirmed": you ran the test, SAW it fail, then SAW it pass. Report redConfirmed and ' +
+        'greenConfirmed from output you actually observed. ' +
+        '"not-applicable": this task has no behaviour to test — a version bump, a config edit, a docs ' +
+        'change — so there was no RED to observe. You must give tddNotApplicableReason, and an agent ' +
+        'that did not write this code will read the task and refute a false claim.',
+    },
+    tddNotApplicableReason: {
+      type: 'string',
+      description: 'why this task had no testable behaviour. Required when tddStatus is "not-applicable".',
+    },
   },
 }
 
@@ -124,7 +142,15 @@ const LENSES = [
 git history for this change. Refute if: the assertion was loosened, the test was
 made tautological, an assertion was deleted, the test was skipped/xfailed, or the
 test does not actually exercise the behavior the task describes. A test that passes
-because it asserts nothing is the single most common way an agent fakes completion.`,
+because it asserts nothing is the single most common way an agent fakes completion.
+
+AND, if the implementer reported tddStatus "not-applicable" — claiming this task had no
+testable behaviour, so no test was needed and no RED was observed — CHECK THAT CLAIM. It is
+the one declaration that skips the TDD evidence check entirely, and the implementer is the
+party that benefits from it. Read the task. A version bump, a config edit or a docs change
+genuinely has nothing to assert. A task that adds behaviour, fixes a bug, or changes a code
+path does not qualify, however inconvenient the test would have been. If the reason does not
+hold up, the claim is FALSE — refute it and say what should have been tested.`,
   },
   {
     key: 'requirement',
@@ -236,7 +262,17 @@ Hard rules:
  - Do NOT weaken, skip, or delete any test to get to green. You will be checked by agents
    that did not write this code, and one of them reads the test diff specifically for that.
 
-Report redConfirmed/greenConfirmed based on output you actually observed, not intent.`
+Report tddStatus, and report it honestly — it is now READ, not just recorded:
+ - "cycle-confirmed" — you ran the test, SAW it fail, then SAW it pass. Set redConfirmed and
+   greenConfirmed from output you actually observed, not intent. Claiming this without both is a
+   rejection, not a shortcut.
+ - "not-applicable" — this task has no behaviour to test (a version bump, a config edit, a docs
+   change), so there was no RED to observe. Give tddNotApplicableReason. An agent that did not write
+   this code will read the task and refute the claim if the task plainly needed a test.
+
+If you could not get a RED for a task that clearly has testable behaviour, say so in summary and set
+succeeded:false. That costs one round. Claiming a cycle you did not run ships a test that asserts
+nothing, and the agent reading your test diff is looking for exactly that.`
 }
 
 function verifyPrompt(task, impl, lens, ctx) {
@@ -253,7 +289,9 @@ The implementer claims:
   ${impl.summary}
   test: ${impl.testFile || '(none reported)'} :: ${impl.testName || '(none reported)'}
   files changed: ${(impl.filesChanged || []).join(', ') || '(none reported)'}
-  red confirmed: ${impl.redConfirmed} | green confirmed: ${impl.greenConfirmed}
+  TDD: ${impl.tddStatus === 'not-applicable'
+    ? `claims NO test was needed — "${impl.tddNotApplicableReason}"`
+    : `cycle-confirmed (red: ${impl.redConfirmed}, green: ${impl.greenConfirmed})`}
 
 YOUR LENS — ${lens.key}:
 ${lens.ask}
@@ -400,6 +438,47 @@ if (ctx.testCommandStatus === 'none-exist') {
   log('this project has no automated tests — proceeding without mechanical verification of TDD cycles')
 }
 
+// The Iron Law's evidence, finally read.
+//
+// redConfirmed/greenConfirmed were declared in the schema, rendered into the verifier's prompt, and
+// consulted by NO code — zero conditionals. So an implementer reporting redConfirmed:false — openly
+// admitting the test never failed first, which is to say it may assert nothing — was accepted exactly
+// like one that ran the whole cycle. The only thing standing in the way was that a verifier MIGHT
+// refute on the prose. That is model judgment, in the file whose opening comment says a script
+// guarantees the barrier precisely because a model can talk itself into skipping ahead.
+//
+// Returns null when the evidence is satisfactory, or the reason it is not.
+function tddEvidenceGap(impl, ctx) {
+  // No suite means RED and GREEN are unobservable by construction. Demanding them here would halt
+  // every genuinely test-less project — the false alarm #31's carve-out exists to prevent. The status
+  // is trustworthy now: an undetectable command halts at load, so "none-exist" really does mean it.
+  if (ctx.testCommandStatus === 'none-exist') return null
+
+  if (impl.tddStatus === 'not-applicable') {
+    // A bare "not applicable" is a free pass any implementer can claim, and a check anyone can opt out
+    // of enforces nothing. The reason is what a verifier can then refute.
+    return impl.tddNotApplicableReason?.trim()
+      ? null
+      : 'claimed the TDD cycle was not applicable but gave no reason — an unexplained exemption is not a declaration'
+  }
+
+  if (impl.tddStatus === 'cycle-confirmed') {
+    // `!== true` deliberately: `undefined` must not pass. Absence of evidence is not evidence, and the
+    // old prompt rendered exactly that absence as the literal text "red confirmed: undefined".
+    if (impl.redConfirmed !== true) {
+      return 'claimed cycle-confirmed but did not confirm RED — the test was never observed failing before the implementation existed, so it may assert nothing'
+    }
+    if (impl.greenConfirmed !== true) {
+      return 'claimed cycle-confirmed but did not confirm GREEN — the test was never observed passing afterwards'
+    }
+    return null
+  }
+
+  // Unrecognised, missing, or non-string. The safe reading of a value we do not understand is "we do
+  // not know", never "everything is fine".
+  return `reported an unrecognised tddStatus (${JSON.stringify(impl.tddStatus)}) — the TDD cycle is unverified`
+}
+
 async function implementAndVerify(task) {
   const impl = await agentTyped(implPrompt(task, ctx), {
     label: `impl:${task.id}`,
@@ -408,6 +487,13 @@ async function implementAndVerify(task) {
   })
   if (!impl) return { task, accepted: false, reason: 'implementer died or was skipped' }
   if (!impl.succeeded) return { task, impl, accepted: false, reason: impl.summary }
+
+  // Before the fan-out, not after: there is nothing for three agents to adversarially verify about
+  // work that already failed its own evidence check, and this workflow spawns too many agents as it
+  // is (#29). Rejecting here also gives the operator a reason that names the gap precisely, rather
+  // than a lens's prose about it.
+  const tddGap = tddEvidenceGap(impl, ctx)
+  if (tddGap) return { task, impl, accepted: false, reason: `TDD evidence: ${tddGap}` }
 
   const verdicts = (
     await parallel(


### PR DESCRIPTION
Fixes #32.

`redConfirmed`/`greenConfirmed` were declared in `IMPL_SCHEMA`, rendered into the verifier's prompt, and consulted by **no code**. Zero conditionals. Acceptance turned on `refutations.length === 0 && verdicts.length > 0` and never looked at them.

So an implementer reporting **`redConfirmed: false`** — openly admitting the test was never observed failing first, which is to say it may assert nothing — was accepted **exactly like** one that ran the whole cycle. Both fields were optional, so omitting them worked too; the verifier's prompt then rendered the literal text `red confirmed: undefined`.

The only thing standing in the way was that a verifier *might* refute on the prose. That's model judgment — in the file whose opening comment says a script guarantees the barrier *precisely because a model can talk itself into skipping ahead*.

## The complication the issue didn't name

**Not every task has a RED phase.** This repo's own `tasks.md` proves it: **T012 was "bump the version in six declarations."** There is no test to see fail first. Strict enforcement would halt on T012, on the CI step, on the CHANGELOG — and someone would rightly rip the check out.

So the implementer **declares** and a different agent **refutes** — the mechanism #31 landed on:

| | |
|---|---|
| **`tddStatus` is required** and enumerated: `cycle-confirmed` \| `not-applicable` | The harness re-asks an implementer that omits it, rather than the workflow deciding silence means yes |
| **`cycle-confirmed` demands `redConfirmed === true` AND `greenConfirmed === true`** | `!== true` deliberately — `undefined` must not pass. Absence of evidence is not evidence |
| **`not-applicable` demands a reason** | A bare exemption is a free pass any implementer can claim; a check anyone can opt out of enforces nothing. The reason is what makes the claim *refutable* |
| **The test-integrity lens checks the claim** | It already reads the test diff and it didn't write the code. A version bump has nothing to assert; a task that adds behaviour doesn't qualify, however inconvenient the test would've been |
| **An unrecognised status is unverified, never fine** | |

The check runs **before the verifier fan-out** — there's nothing for three agents to adversarially verify about work that already failed its own evidence check, and this workflow spawns too many agents as it is (#29).

## The #31 interaction

A project with no suite cannot observe RED or GREEN by construction, so the evidence isn't demanded of it — otherwise this would halt every test-less project, the exact false alarm #31's carve-out exists to prevent.

That exemption is **only safe because #31 made the status trustworthy**: an undetectable command now halts at load, so `none-exist` really does mean none exist. Fixing #31 first is what made #32 fixable without inventing a new concept.

## Verification

```
node --test      34 pass, 0 fail   (9 new, all RED against the unmodified file first)
tests/smoke.sh   44 passed, 0 failed
spawns           1 (choke point holds)
code             487 lines (limit 500)
```

**Every mutation executed.** One stayed green and exposed a weak test: asserting `/not-applicable/` and `/refute/` on the lens prompt **passes with the cross-check deleted**, because the base lens already says *"Refute if…"* and `verifyPrompt` renders *"claims NO test was needed"*. I'd asserted on text I'd have had anyway. The assertions now match text unique to the cross-check, and the mutation goes red.

That's the third time this session a loose match made a test unfalsifiable. Reasoning about a mutation is not running it.

Driving the shipped file with this repo's own non-TDD task:

```
T012 "bump the version in six declarations", declared not-applicable with a reason
  -> {"completed":1,"halted":false}      the design works on a realistic task list
```

## Note for #29 / #30

Code is now **487 lines against the 500 limit**, and the Workflow harness offers no module system to extract into. B and C will breach it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)