### PR TITLE
fix: a dead verifier no longer silently shrinks the quorum (#28)

### DIFF
--- a/tests/workflow.test.js
+++ b/tests/workflow.test.js
@@ -667,6 +667,122 @@ test('#32: the test-integrity lens is told to refute a FALSE not-applicable clai
     'the lens needs the line between a genuine exemption and an inconvenient test')
 })
 
+// =============================================================================================
+// #28 — a dead verifier silently shrank the quorum.
+//
+// The verdicts were collected with `.filter(Boolean)` — the same shape as the batch collector's
+// silent drop — and acceptance read `refutations.length === 0 && verdicts.length > 0`. All three
+// dead correctly blocked the task. TWO dead did not: the task was accepted on the strength of a
+// SINGLE lens, with no signal that the other two never reported.
+//
+// The lenses are deliberately DIVERSE, not redundant — "redundant verifiers find the same thing;
+// diverse ones catch failure modes the others are blind to". So losing two of three is not 33% less
+// confidence. It can mean the one dimension that would have caught the defect is the one that went
+// silent — including test-integrity, the lens that reads the test diff for a weakened assertion,
+// described in this file as "the single most common way an agent fakes completion".
+// =============================================================================================
+
+const LENS_KEYS = ['test-integrity', 'requirement', 'regression']
+
+test('#28: two dead verifiers must not accept a task on the strength of one', async () => {
+  const g = FIXTURES.twoPhasesSequential()
+  const { result } = await drive({
+    canned: withOverrides(baseCanned(g), [
+      [l => l === 'verify:T001:test-integrity', () => null],
+      [l => l === 'verify:T001:requirement', () => null],
+      // only `regression` reports, and it says fine
+    ]),
+  })
+  assert.ok(result.halted,
+    `a task must not be accepted on 1 of 3 lenses; got ${JSON.stringify(result)}`)
+  assert.match(JSON.stringify(result.rejected), /verif|lens|quorum|1 of 3|did not report/i,
+    'the rejection must say the verification was incomplete, not invent a different reason')
+})
+
+test('#28: even ONE dead verifier blocks — a dead lens is uncertainty, and uncertainty refutes', async () => {
+  const g = FIXTURES.twoPhasesSequential()
+  const { result } = await drive({
+    canned: withOverrides(baseCanned(g), [[l => l === 'verify:T001:test-integrity', () => null]]),
+  })
+  // The file's own bias, verbatim: "Default to refuted=true when uncertain — a task wrongly accepted
+  // ships a bug; a task wrongly refuted costs one more round." A lens that never reported is the
+  // uncertainty that rule is about.
+  assert.ok(result.halted, `2 of 3 lenses is not a verified task; got ${JSON.stringify(result)}`)
+})
+
+test('#28: all three dead still blocks (regression guard — this half already worked)', async () => {
+  const g = FIXTURES.twoPhasesSequential()
+  const { result } = await drive({
+    canned: withOverrides(baseCanned(g), [[l => l.startsWith('verify:T001'), () => null]]),
+  })
+  assert.ok(result.halted, 'three dead verifiers must never accept')
+})
+
+test('#28: the reason names WHICH lenses went silent, not just that something did', async () => {
+  const g = FIXTURES.twoPhasesSequential()
+  const { result } = await drive({
+    canned: withOverrides(baseCanned(g), [
+      [l => l === 'verify:T001:test-integrity', () => null],
+      [l => l === 'verify:T001:requirement', () => null],
+    ]),
+  })
+  const reason = JSON.stringify(result.rejected)
+  // "verification incomplete" sends the operator to read three transcripts. Naming the lens tells
+  // them whether the dimension that matters to this task is the one that died.
+  assert.match(reason, /test-integrity/, 'the reason must name the silent lens')
+  assert.match(reason, /requirement/, 'both silent lenses must be named')
+  assert.ok(!/regression/.test(reason.replace(/regression check|regressions/g, '')),
+    'the lens that DID report must not be listed as silent')
+})
+
+test('#28: a lens whose THUNK throws is silent too, not vanished', async () => {
+  // agentTyped returning null is handled by the .then() — that null never reaches the collector. The
+  // index-map exists for the other path: a throw inside the thunk itself. verifyPrompt interpolates
+  // impl fields, so a hostile impl reaches it. parallel() then converts that throw to null, and
+  // filtering the null away would drop the lens, leave silent.length === 0, and accept the task on
+  // two lenses — the bug, reintroduced through the back door.
+  //
+  // This test exists because the mutation `raw.map(...)` -> `raw.filter(Boolean)` was GREEN without
+  // it: none of the other fixtures put a real null in `raw`, so the belt-and-braces looked like dead
+  // code while actually being load-bearing.
+  const g = FIXTURES.twoPhasesSequential()
+  let boom = false
+  const hostileImpl = {
+    id: 'T001', succeeded: true, tddStatus: 'cycle-confirmed', redConfirmed: true, greenConfirmed: true,
+    // verifyPrompt reads .summary — throw the first time a lens's prompt is built.
+    get summary() { if (!boom) { boom = true; throw new Error('prompt construction exploded') } return 's' },
+  }
+  const { result } = await drive({
+    canned: (label) => (label.startsWith('impl:') ? hostileImpl : baseCanned(g)(label)),
+  })
+  assert.ok(result.halted, `a lens whose thunk threw must not silently shrink the quorum; got ${JSON.stringify(result)}`)
+  assert.match(JSON.stringify(result.rejected), /never reported|unverified/i,
+    'a thrown thunk must be reported as a lens that did not report')
+})
+
+test('#28: a refutation still wins over a dead lens — the refuter is the more urgent news', async () => {
+  const g = FIXTURES.twoPhasesSequential()
+  const { result } = await drive({
+    canned: withOverrides(baseCanned(g), [
+      [l => l === 'verify:T001:test-integrity', () => ({ refuted: true, reason: 'assertion was deleted' })],
+      [l => l === 'verify:T001:requirement', () => null],
+    ]),
+  })
+  assert.ok(result.halted)
+  assert.match(JSON.stringify(result.rejected), /assertion was deleted/,
+    'a real refutation must survive into the reason, not be masked by the quorum complaint')
+})
+
+test('#28: all three reporting and none refuting still accepts — the happy path is untouched', async () => {
+  const g = FIXTURES.twoPhasesSequential()
+  const { result, spawned } = await drive({ canned: baseCanned(g) })
+  assert.ok(!result.halted, `a fully verified task must still be accepted; got ${JSON.stringify(result)}`)
+  assert.equal(result.completed, 2)
+  for (const k of LENS_KEYS) {
+    assert.ok(spawned.includes(`verify:T001:${k}`), `lens ${k} should have run`)
+  }
+})
+
 test('SC-017: a done:true task is excluded from total, and an unreached phase is notAttempted', async () => {
   const g = FIXTURES.twoPhases()
   const { result } = await drive({

--- a/workflows/speckit-workflow.js
+++ b/workflows/speckit-workflow.js
@@ -495,27 +495,51 @@ async function implementAndVerify(task) {
   const tddGap = tddEvidenceGap(impl, ctx)
   if (tddGap) return { task, impl, accepted: false, reason: `TDD evidence: ${tddGap}` }
 
-  const verdicts = (
-    await parallel(
-      LENSES.map(lens => () =>
-        agentTyped(verifyPrompt(task, impl, lens, ctx), {
-          label: `verify:${task.id}:${lens.key}`,
-          phase: 'Verify',
-          schema: VERDICT_SCHEMA,
-        }).then(v => (v ? { ...v, lens: lens.key } : null)),
-      ),
-    )
-  ).filter(Boolean)
+  // Do NOT .filter(Boolean) these — that is what let a dead lens vanish. A null verdict became an
+  // absence, the quorum silently shrank, and a task could be accepted on the strength of ONE lens
+  // while the other two never reported. Index-map the nulls into an explicit `silent` record instead,
+  // exactly as the batch collector does, so a lens that did not answer is a fact rather than a gap.
+  const raw = await parallel(
+    LENSES.map(lens => () =>
+      agentTyped(verifyPrompt(task, impl, lens, ctx), {
+        label: `verify:${task.id}:${lens.key}`,
+        phase: 'Verify',
+        schema: VERDICT_SCHEMA,
+      }).then(v => (v ? { ...v, lens: lens.key } : { lens: lens.key, silent: true })),
+    ),
+  )
+  const verdicts = raw.map((v, i) => v || { lens: LENSES[i].key, silent: true })
 
-  // ANY lens refuting blocks the task. This is not a majority vote: the lenses look at
-  // different things, so a single one finding a weakened test is decisive on its own.
   const refutations = verdicts.filter(v => v.refuted)
+  const silent = verdicts.filter(v => v.silent).map(v => v.lens)
+
+  // ANY lens refuting blocks the task. This is not a majority vote: the lenses look at different
+  // things, so a single one finding a weakened test is decisive on its own.
+  //
+  // And EVERY lens must report. The old rule — `verdicts.length > 0` — correctly blocked when all
+  // three died, and quietly accepted when two did. But the lenses are diverse, not redundant (see
+  // LENSES above), so two silent lenses are not "a third less confidence": the dimension that would
+  // have caught this defect may be precisely the one that went quiet, and test-integrity — the lens
+  // that reads the test diff for a deleted assertion — can vanish without a trace.
+  //
+  // A lens that never reported is uncertainty, and this file's rule for uncertainty is written into
+  // the verifier prompt itself: default to refuted, because a task wrongly accepted ships a bug while
+  // a task wrongly refuted costs one more round. Halting on a dead lens costs a resume, which replays
+  // the cached prefix. Accepting on a shrunken quorum costs a bug that three agents were supposed to
+  // catch and one of them wasn't asked.
+  const reasons = [
+    ...refutations.map(r => `[${r.lens}] ${r.reason}`),
+    ...(silent.length
+      ? [`${silent.length} of ${LENSES.length} lenses never reported (${silent.join(', ')}) — the task is unverified, not verified`]
+      : []),
+  ]
+
   return {
     task,
     impl,
     verdicts,
-    accepted: refutations.length === 0 && verdicts.length > 0,
-    reason: refutations.map(r => `[${r.lens}] ${r.reason}`).join(' | '),
+    accepted: refutations.length === 0 && silent.length === 0,
+    reason: reasons.join(' | '),
   }
 }
 


### PR DESCRIPTION
Fixes #28. The last of the evidence-discarded family — #31 and #32 were the others.

The verdicts were collected with `.filter(Boolean)` — **the same shape as the batch collector's silent drop** — and acceptance read:

```js
accepted: refutations.length === 0 && verdicts.length > 0
```

All three lenses dead correctly blocked. **Two dead did not**: the task was accepted on the strength of a **single lens**, with no signal that the other two never reported.

## Why two-of-three isn't "a third less confidence"

The lenses are deliberately **diverse, not redundant**, and this file says so at their declaration: *"redundant verifiers find the same thing; diverse ones catch failure modes the others are blind to."*

So losing two doesn't reduce confidence proportionally — it can mean **the one dimension that would have caught the defect is the one that went quiet**. Including `test-integrity`, the lens that reads the test diff for a deleted assertion, which this same file calls *"the single most common way an agent fakes completion."* It could vanish without a trace.

## The fix

Every lens must report. A lens that didn't answer is **uncertainty**, and this file's rule for uncertainty is already written into the verifier prompt: *default to refuted, because a task wrongly accepted ships a bug while a task wrongly refuted costs one more round.*

Halting on a dead lens costs a resume, which replays the cached prefix. Accepting on a shrunken quorum costs a bug that three agents were supposed to catch and one of them was never asked.

- Nulls are **index-mapped into explicit `silent` records**, not filtered away — same remedy as the batch collector. A lens that didn't answer is a fact, not a gap.
- The reason **names which lenses went silent**. "Verification incomplete" sends the operator to read three transcripts; naming the lens tells them whether the dimension that mattered is the one that died.
- A real refutation still **leads** the reason — it's the more urgent news.

**There is no `.filter(Boolean)` on a `parallel()` result left anywhere in this file.**

## Verification

```
node --test      41 pass, 0 fail   (7 new, all RED against the unmodified file first)
tests/smoke.sh   44 passed, 0 failed
spawns           1
code             493 lines (limit 500)
```

**Every mutation executed** — and one stayed green, exposing code that *looked* dead and is load-bearing.

`agentTyped`'s null is absorbed by the `.then()`, so no fixture ever put a true null in the collector, and mutating `raw.map(...)` → `raw.filter(Boolean)` changed nothing. But a throw in the **thunk** — `verifyPrompt` interpolates `impl` fields — *does* produce a null, and filtering it would drop the lens, leave `silent.length === 0`, and accept on two lenses: **the bug, through the back door**. There's now a test with a throwing getter that covers it, and the mutation goes red.

Fourth time this session the mutation pass caught something reasoning didn't.

## Note for #29 / #30

Code is at **493 lines against the 500 limit** — seven to spare. The Workflow harness offers no module system to extract into, and the limit counts code rather than comments (clarified in 5.1.0), so the remedy is real decomposition, not deleting the comments that document each measured trap. Either B or C will force that conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)