### PR TITLE
fix: helpers fail loudly instead of returning sentinels at exit 0 (#27)

### DIFF
--- a/hooks/speckit-helper.sh
+++ b/hooks/speckit-helper.sh
@@ -2,8 +2,58 @@
 # speckit-helper.sh - Pre-flight helper for speckit commands
 # Centralizes all pre-flight shell logic to avoid Claude Code permission
 # issues with $(), ||, &&, and | operators in !` ` commands.
+#
+# ---------------------------------------------------------------------------------------------
+# THE CONTRACT. Every subcommand is one of two kinds, and the difference is the exit code.
+#
+#   FETCHER  — "give me X". Prints X on stdout, exit 0. If X does not exist that is a FAILURE:
+#              the reason goes to STDERR and the exit code is NON-ZERO. It must be impossible for
+#              a caller to mistake the reason for the answer.
+#
+#   PREDICATE — "is X true?". Prints the answer on stdout AND returns it as the exit code
+#              (0 = yes, 1 = no). Both, deliberately: a shell caller writes `helper foo && ...`,
+#              a model reads the string. Neither contract is privileged, so neither breaks.
+#
+# This used to be one undifferentiated pile that printed a sentinel and exited 0 for everything,
+# and it cost real work twice:
+#
+#   * `spec` printed the six characters NO_SPEC at exit 0 when the artifact was missing. A command
+#     told to "load spec.md" loaded that string and carried on. It happened during the 5.1.0 run —
+#     the spec directory did not match the branch, every artifact subcommand reported NO_SPEC at
+#     exit 0, and nothing noticed until a human read the output. (#27)
+#   * `rtk-available` printed RTK_MISSING at exit 0, while quality-tooling.md documented
+#     `helper rtk-available && rtk pytest || pytest`. The && branch ALWAYS ran. The guard did not
+#     guard; the pattern only fell back because rtk itself then died with 127 — which is what plain
+#     `rtk pytest || pytest` does, except noisier, in a rule that calls rtk "a silent, non-blocking
+#     enhancement". The helper's contract was "branch on the string"; the rule's was "branch on the
+#     exit code"; they disagreed and the failure was silent. (#27, same class)
+#
+# Constitution principle 5: helpers fail loudly; no exit-0 sentinel a caller can ignore.
+# ---------------------------------------------------------------------------------------------
+
+# A fetcher could not fetch. STDERR, never stdout — a caller redirecting stdout into a variable
+# must get nothing, not an explanation it might use as the answer.
+die() {
+  echo "$*" >&2
+  exit 1
+}
 
 BRANCH=$(git branch --show-current 2>/dev/null | sed 's|^feature/||')
+
+# The spec directory name and the branch name are ONE contract, not two: artifacts live at
+# .specify/specs/$(git branch --show-current | sed 's|^feature/||')/. Nothing states this — not
+# /speckit.specify, which asks for a 2-4 word kebab-case name and separately says to branch
+# `feature/<name>`, leaving the equality implied by juxtaposition. When they diverge, every artifact
+# is missing for a reason that has nothing to do with the artifacts. Say so specifically.
+missing_artifact() {  # $1 = artifact filename, e.g. spec.md
+  local want=".specify/specs/$BRANCH/$1"
+  local found
+  found="$(ls -d .specify/specs/*/ 2>/dev/null | sed 's|.specify/specs/||; s|/$||' | tr '\n' ' ')"
+  if [ -z "$found" ]; then
+    die "no $1: $want does not exist, and .specify/specs/ holds no feature directories at all. Run /speckit.specify first."
+  fi
+  die "no $1: expected it at $want (the spec directory MUST be named after the branch, minus any 'feature/' prefix). Existing spec directories: ${found% }. Either rename the directory to '$BRANCH', or switch to the branch that matches it."
+}
 
 # Resolve what a PR is diffed against, and never fail doing it. Prints a ref, or nothing
 # when HEAD is the root commit (no parent to compare with).
@@ -31,17 +81,29 @@ case "$1" in
     ;;
 
   # --- Spec artifacts (branch-scoped) ---
+  # --- FETCHERS: absence is a failure, and it goes to stderr with a non-zero exit ---
   spec)
-    cat ".specify/specs/$BRANCH/spec.md" 2>/dev/null || echo "NO_SPEC"
+    cat ".specify/specs/$BRANCH/spec.md" 2>/dev/null || missing_artifact spec.md
     ;;
   plan)
-    cat ".specify/specs/$BRANCH/plan.md" 2>/dev/null || echo "NO_PLAN"
+    cat ".specify/specs/$BRANCH/plan.md" 2>/dev/null || missing_artifact plan.md
     ;;
+  # --- PREDICATE: the answer is the exit code AND the string ---
   check-spec)
-    ls ".specify/specs/$BRANCH/spec.md" 2>/dev/null && echo "SPEC_FOUND: $BRANCH" || echo "NO_SPEC_FOR_BRANCH"
+    if [ -f ".specify/specs/$BRANCH/spec.md" ]; then
+      echo "SPEC_FOUND: $BRANCH"
+    else
+      echo "NO_SPEC_FOR_BRANCH: $BRANCH"
+      exit 1
+    fi
     ;;
   check-plan)
-    test -f ".specify/specs/$BRANCH/plan.md" && echo "PLAN_FOUND: $BRANCH" || echo "NO_PLAN_FOR_BRANCH"
+    if [ -f ".specify/specs/$BRANCH/plan.md" ]; then
+      echo "PLAN_FOUND: $BRANCH"
+    else
+      echo "NO_PLAN_FOR_BRANCH: $BRANCH"
+      exit 1
+    fi
     ;;
   check-artifacts)
     for f in tasks.md plan.md spec.md; do
@@ -55,6 +117,10 @@ case "$1" in
     done
     ;;
   clarifications)
+    # Two different absences, and they are not the same news: no spec at all is a broken
+    # precondition; a spec with no Clarifications section is a normal, expected state that
+    # /speckit.clarify exists to fix.
+    [ -f ".specify/specs/$BRANCH/spec.md" ] || missing_artifact spec.md
     grep -A 100 "## Clarifications" ".specify/specs/$BRANCH/spec.md" 2>/dev/null || echo "NO_CLARIFICATIONS_SECTION"
     ;;
 
@@ -78,16 +144,18 @@ case "$1" in
 
   # --- Global spec-kit resources ---
   constitution)
-    cat .specify/memory/constitution.md 2>/dev/null || echo "NO_CONSTITUTION"
+    cat .specify/memory/constitution.md 2>/dev/null || die "no constitution: .specify/memory/constitution.md does not exist. Run /speckit.init to scaffold it, or /speckit.constitution to populate it."
     ;;
   list-specs)
-    ls -d .specify/specs/*/ 2>/dev/null || echo "NO_SPECS"
+    ls -d .specify/specs/*/ 2>/dev/null || die "no specs: .specify/specs/ holds no feature directories. Run /speckit.specify first."
     ;;
   list-specs-dir)
     ls .specify/specs/ 2>/dev/null || echo "NO_SPECS_DIR"
     ;;
   check-specify-dir)
-    test -d .specify && echo "EXISTS" || echo "NOT_FOUND"
+    # PREDICATE. /speckit.init asks this precisely to learn the answer, so NOT_FOUND is a normal
+    # reply, never a failure — it is the whole reason init exists.
+    if [ -d .specify ]; then echo "EXISTS"; else echo "NOT_FOUND"; exit 1; fi
     ;;
 
   # --- Project detection ---
@@ -185,12 +253,25 @@ case "$1" in
 
   # --- RTK CLI output compression (optional, auto-detected) ---
   rtk-available)
-    # Prints RTK_AVAILABLE or RTK_MISSING; always exits 0 so callers can
-    # branch on the output without tripping `set -e`.
+    # PREDICATE. The answer is BOTH the string and the exit code.
+    #
+    # This used to always exit 0 — the comment said so on purpose, "so callers can branch on the
+    # output". But the only caller is quality-tooling.md, which branches on the EXIT CODE:
+    #
+    #     helper rtk-available && rtk pytest -q || pytest -q
+    #
+    # With a constant 0 the && branch ALWAYS ran, rtk or no rtk. The guard did not guard: the
+    # pattern only fell back because `rtk` itself then died with 127, which is exactly what a bare
+    # `rtk pytest || pytest` does — except it prints a command-not-found error, in a rule whose
+    # whole point is that rtk stays "a silent, non-blocking enhancement". Verified by running the
+    # documented line with rtk off PATH: it took the rtk branch.
+    #
+    # The string still prints, so a model reading output loses nothing.
     if command -v rtk >/dev/null 2>&1; then
       echo "RTK_AVAILABLE"
     else
       echo "RTK_MISSING"
+      exit 1
     fi
     ;;
   rtk-run)

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -280,6 +280,75 @@ else
 fi
 
 # --- Tier 1: helper runs ------------------------------------------------------------
+head_ "Helper contract"
+
+# A fetcher that prints a sentinel at exit 0 lets a command sail past a missing precondition and
+# invent its own answer. `spec` printed the six characters NO_SPEC and exited 0; a command told to
+# "load spec.md" loaded that string. It happened during the 5.1.0 run and nothing noticed until a
+# human read the output. Constitution principle 5. (#27)
+#
+# Driven in a scratch repo, because the assertion is about what happens when the artifact is ABSENT
+# and this repo has one.
+hc_tmp="$(mktemp -d)"
+(
+  cd "$hc_tmp" || exit 1
+  git init -q . 2>/dev/null
+  git checkout -q -b feature/nothing-here 2>/dev/null
+  mkdir -p .specify/specs/some-other-name
+  : > .specify/specs/some-other-name/spec.md
+) >/dev/null 2>&1
+
+hc_fail=0
+# spec/plan: the directory exists but is named for a DIFFERENT branch — the 5.1.0 case exactly.
+# constitution: never scaffolded.
+for sub in spec plan constitution; do
+  out="$(cd "$hc_tmp" && "$HELPER" "$sub" 2>/dev/null)"; rc=$?
+  if [ "$rc" -eq 0 ]; then
+    bad "helper '$sub' exits 0 with the artifact absent — a caller cannot tell the answer from the failure (#27)"
+    hc_fail=1
+  elif [ -n "$out" ]; then
+    bad "helper '$sub' printed '$out' to STDOUT while failing — a caller capturing stdout would use it as the answer (#27)"
+    hc_fail=1
+  fi
+done
+
+# list-specs needs its own fixture: in the one above a spec directory DOES exist, so exiting 0 is the
+# correct answer. Its failure case is a .specify/ with no feature directories at all.
+hc_empty="$(mktemp -d)"; mkdir -p "$hc_empty/.specify/specs"
+out="$(cd "$hc_empty" && "$HELPER" list-specs 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 0 ] || [ -n "$out" ]; then
+  bad "helper 'list-specs' must fail loudly when .specify/specs/ is empty; got '$out' at exit $rc (#27)"
+  hc_fail=1
+fi
+rm -rf "$hc_empty"
+
+[ "$hc_fail" -eq 0 ] && ok "fetchers fail loudly: non-zero exit, nothing on stdout, reason on stderr (#27)"
+
+# The reason must be actionable. Every artifact goes missing at once when the spec directory does not
+# match the branch, and that is a fact about the DIRECTORY, not the artifacts — the run that hit this
+# lost an hour to it. The message has to say so.
+#
+# Assert on text unique to the CONTRACT, not merely on the word "branch" — the message says "switch
+# to the branch that matches it" elsewhere, so a loose `grep -qi branch` stays green with the whole
+# contract sentence deleted. Verified: it did.
+hint="$(cd "$hc_tmp" && "$HELPER" spec 2>&1 >/dev/null)"
+hint_fail=0
+grep -q "some-other-name" <<<"$hint" || { bad "the message must LIST the spec directories that do exist; got: $hint"; hint_fail=1; }
+grep -q "MUST be named after the branch" <<<"$hint" || { bad "the message must state the branch↔directory contract, which is the actual cause; got: $hint"; hint_fail=1; }
+[ "$hint_fail" -eq 0 ] && ok "a missing artifact names the branch↔directory contract and lists what does exist"
+
+# PREDICATES answer; they do not fail. /speckit.init asks check-specify-dir precisely to learn that
+# .specify/ is absent — that is the whole reason init exists, so the string must still be there.
+pred_out="$(cd "$hc_tmp" && "$HELPER" check-specify-dir 2>/dev/null)"
+if [ "$pred_out" = "EXISTS" ]; then
+  ok "check-specify-dir still answers on stdout"
+else
+  # .specify EXISTS in the scratch repo, so this branch means the predicate lost its string.
+  bad "check-specify-dir must print its answer, not just signal it — /speckit.init branches on the string"
+fi
+
+rm -rf "$hc_tmp"
+
 head_ "Workflow resilience"
 
 # These guard shape invariants that tests/workflow.test.js CANNOT reach. A behaviour test proves the
@@ -380,9 +449,44 @@ head_ "Helper"
 
 if [ -x "$HELPER" ]; then ok "speckit-helper.sh is executable"; else bad "speckit-helper.sh is not executable"; fi
 
-for sub in branch recent-commits rtk-available; do
+for sub in branch recent-commits; do
   if "$HELPER" "$sub" >/dev/null 2>&1; then ok "helper '$sub' runs"; else bad "helper '$sub' exits non-zero"; fi
 done
+
+# `rtk-available` is a PREDICATE, and "does it run" is the wrong question for one — that is exactly
+# how the broken contract survived. It used to always exit 0, so quality-tooling.md's documented
+# `helper rtk-available && rtk pytest || pytest` took the rtk branch even with rtk absent. The guard
+# did not guard. This suite asserted "helper 'rtk-available' runs" and was satisfied.
+#
+# The right question is whether the ANSWER matches reality — on this machine, and on CI, where rtk is
+# not installed and the exit code must therefore be 1.
+rtk_out="$("$HELPER" rtk-available 2>/dev/null)"; rtk_rc=$?
+if command -v rtk >/dev/null 2>&1; then
+  if [ "$rtk_out" = "RTK_AVAILABLE" ] && [ "$rtk_rc" -eq 0 ]; then
+    ok "helper rtk-available agrees with reality (present: RTK_AVAILABLE, exit 0)"
+  else
+    bad "rtk is on PATH but the helper said '$rtk_out' / exit $rtk_rc"
+  fi
+else
+  if [ "$rtk_out" = "RTK_MISSING" ] && [ "$rtk_rc" -ne 0 ]; then
+    ok "helper rtk-available agrees with reality (absent: RTK_MISSING, non-zero)"
+  else
+    bad "rtk is NOT on PATH but the helper said '$rtk_out' / exit $rtk_rc — the documented '&& rtk … || …' pattern would run rtk anyway"
+  fi
+fi
+
+# ...and prove the documented pattern actually branches, in both directions. This is the check that
+# would have caught the original bug: it drives quality-tooling.md's own line rather than the helper.
+if PATH=/usr/bin:/bin "$HELPER" rtk-available >/dev/null 2>&1; then
+  branch_taken="rtk"
+else
+  branch_taken="fallback"
+fi
+if [ "$branch_taken" = "fallback" ]; then
+  ok "the documented 'rtk-available && rtk … || …' pattern falls back when rtk is off PATH"
+else
+  bad "with rtk off PATH the documented pattern still took the rtk branch — rtk-available is not a usable predicate"
+fi
 
 # The helper must survive the repos it will actually meet, not just this one. The pr-*
 # subcommands used to diff against `main` and fall back to HEAD~1 with nothing after it, so


### PR DESCRIPTION
Fixes #27 — the bug that bit the 5.1.0 run itself.

Every subcommand printed a sentinel and exited 0, so **a caller could not tell an answer from a failure**. `spec` printed the six characters `NO_SPEC` at exit 0 when the artifact was missing, and a command told to *"load spec.md"* loaded that string and carried on.

That's not hypothetical. During the 5.1.0 run the spec directory didn't match the branch, **every artifact subcommand reported `NO_SPEC` at exit 0**, and nothing noticed until a human read the output. Constitution principle 5 — *"helpers fail loudly; no exit-0 sentinel a caller can ignore"* — violated by the helper the principle was written about.

## Why "just exit non-zero" would have been wrong

The subcommands were never one kind of thing:

| | |
|---|---|
| **FETCHER** — *"give me X"* | Absence is a **failure**: reason to **stderr**, non-zero exit, and **nothing on stdout** that could be mistaken for the answer |
| **PREDICATE** — *"is X true?"* | The answer is **both** the string and the exit code |

Both, deliberately: `/speckit.init` branches on the **string** (*"if `.specify/` EXISTS"*), `quality-tooling.md` branches on the **exit code**. Neither contract is privileged, so neither breaks. A blanket non-zero would have broken init, whose entire purpose is to ask whether `.specify/` is absent.

## A second, live instance of the same class

Separating them surfaced this. `rtk-available` printed `RTK_MISSING` and **exited 0** — its comment said so on purpose, *"so callers can branch on the output."* But its only caller is `quality-tooling.md`, which branches on the exit code:

```bash
helper rtk-available && rtk pytest -q || pytest -q
```

**With a constant 0 the `&&` branch always ran.** The guard did not guard. The pattern only fell back because `rtk` itself then died with 127 — identical to a bare `rtk pytest || pytest`, except it prints command-not-found, in a rule whose whole point is that rtk stays *"a silent, non-blocking enhancement."*

Verified by running the documented line with rtk off PATH:

```
helper says: RTK_MISSING
exit code:   0
-> && branch taken: runs "rtk pytest"   <<< rtk IS MISSING. The guard did not guard.
```

The helper's contract was *branch on the string*; the rule's was *branch on the exit code*. They disagreed, and the failure was silent.

## The message names the actual cause

The spec directory name and the branch name are **one contract** — artifacts live at `.specify/specs/$(branch minus feature/)/` — and nothing states it. `/speckit.specify` asks for a "2-4 word kebab-case" name and separately says to branch `feature/<name>`, leaving the equality implied by juxtaposition. When they diverge, **every** artifact goes missing at once, for a reason that has nothing to do with the artifacts.

Re-enacting the exact 5.1.0 failure against the fixed helper:

```
BEFORE:  stdout: NO_SPEC        exit: 0
AFTER:   stdout: (empty)        exit: 1
         stderr: no spec.md: expected it at .specify/specs/speckit-workflow-multi-repo-and-
                 resilience/spec.md (the spec directory MUST be named after the branch, minus
                 any 'feature/' prefix). Existing spec directories: speckit-workflow-hardening.
                 Either rename the directory to '…', or switch to the branch that matches it.
```

That's the hour it cost, reduced to one line.

## The guard encoded the bug

The smoke suite asserted **"helper 'rtk-available' runs"** — the wrong question for a predicate, and exactly how the broken contract survived. It lumped a predicate in with two fetchers and checked that it exits 0, which is the bug.

It now asserts the **answer matches reality in both directions**, and drives `quality-tooling.md`'s own documented line to prove it branches. That check goes red on CI-without-rtk if the predicate ever regresses.

## Verification

```
tests/smoke.sh   48 passed, 0 failed   (was 44 — four new guards)
node --test      41 pass, 0 fail       (unaffected)
```

**Every mutation executed.** One stayed green and caught a loose assertion: `grep -qi branch` passed with the whole contract sentence deleted, because the message says *"switch to the branch that matches it"* elsewhere. Fifth time this session a loose match made a test unfalsifiable — and the fifth time only running the mutation revealed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)