### PR TITLE
feat: cap fan-out amplitude so a run stops self-inflicting 429/529 (#29)

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -17,6 +17,25 @@
 >
 > This is a clarification of intent, not a relaxation. If the *code* exceeds 500 lines, split the file.
 
+### The one exemption: `workflows/speckit-workflow.js`
+
+The file limit's remedy is "split the file." For a Claude Code **Workflow script** that remedy does not
+exist, so the limit is scoped to exclude this one file — deliberately, and with the reason on record.
+
+The Workflow harness executes the script as a **function body**, injecting `agent`/`parallel`/`phase`/
+`log`/`args` as globals. A static `import` is therefore a **compile error** — *"Cannot use import
+statement outside a module"* — not a policy choice we could argue with. Verified, not assumed. `require`
+is undefined (ESM context), and the harness documents no filesystem or Node API access, so dynamic
+`import()` is not something the plugin's core may bet on either. There is no module to extract into.
+
+The alternative was deleting comments to fit, and in this file that is the worst available trade: each
+one records a defect that was *measured* — a `throw null` that killed the error handler, a `const` that
+threw on every path, a `gate &&` that reported 2/2 across six dead gates. Deleting them keeps the
+complexity and loses the only reason anyone would not reintroduce it.
+
+**Every other file keeps the 500-line limit.** If a second file ever needs this exemption, that is a
+signal the harness constraint has spread, and it deserves a fresh argument rather than a precedent.
+
 ## Testing Requirements
 - Test existing patterns when framework present
 - Focus on business logic and edge cases

--- a/tests/workflow.test.js
+++ b/tests/workflow.test.js
@@ -783,6 +783,196 @@ test('#28: all three reporting and none refuting still accepts — the happy pat
   }
 })
 
+// =============================================================================================
+// #29 — fan-out amplitude. Measured, not argued: 2 tasks => 12 agents, peak 6, of which THREE run
+// a full test suite where one would do. On a 728-test / ~12-minute suite that is the shape that
+// trips a shared rate limit, and the retries then pile on more load. One verifier hit 529 twenty-one
+// times before the run died.
+//
+// PRIOR ART — the adversarial review measured all of this; do not re-derive it:
+//   * the semaphore ALGORITHM survived every attack (no lost wakeup, no starvation at 200 arrivals,
+//     balanced accounting across the retry path, correct under drop-to-1 and nested fan-out). It is
+//     not the thing that was broken.
+//   * its INPUT VALIDATION was: `0`/`-1` hang the run forever having spawned nothing; `"abc"` deletes
+//     the cap entirely (measured peak 20/20, because `active >= NaN` is always false); `2.5` silently
+//     becomes 3. `??` does not catch `0` — which is how a user writes "unlimited".
+//   * `assert.ok(peak <= cap)` is a CEILING WITH NO FLOOR: it passes more easily the more broken the
+//     file is. Break the loader and peak collapses to 1. Assertions below use strictEqual against the
+//     cap the test passed in, plus a floor, plus a fixture whose UNBOUNDED peak exceeds the cap.
+// =============================================================================================
+
+/** Drive with an instrumented stub that records true concurrency. The stub MUST await. */
+async function driveMeasuringPeak({ canned, args }) {
+  let inFlight = 0, peak = 0
+  const spawned = []
+  const logs = []
+  const agent = async (p, o = {}) => {
+    spawned.push(o.label)
+    peak = Math.max(peak, ++inFlight)
+    await new Promise(r => setTimeout(r, 2))   // a real yield — see the un-awaited-stub trap
+    inFlight--
+    return canned(o.label, o)
+  }
+  const result = await makeRun(loadWorkflowSource())(
+    agent, parallelThrowToNull, () => {}, m => logs.push(m), args ?? { featureDir: '/f' })
+  return { result, peak, spawned, logs }
+}
+
+/** N parallel tasks: unbounded peak is well above any cap we test, so the assertion can fail. */
+const wideGraph = (n) => graph([{
+  name: 'Phase 1',
+  tasks: Array.from({ length: n }, (_, i) => task(`T${String(i + 1).padStart(3, '0')}`, { parallel: true, files: [`f${i}.js`] })),
+}])
+
+test('#29: concurrency is capped at 4 by default', async () => {
+  const g = wideGraph(8)
+  const { peak } = await driveMeasuringPeak({ canned: baseCanned(g) })
+  // 8 [P] tasks x (1 impl + 3 verifiers) is an unbounded peak far above 4 — so this CAN fail.
+  assert.equal(peak, 4, `expected peak exactly 4, got ${peak} — a cap that never binds is not a cap`)
+})
+
+test('#29: args.maxConcurrency is honoured, and the assertion uses the cap the test passed in', async () => {
+  for (const cap of [1, 2, 6]) {
+    const g = wideGraph(8)
+    const { peak } = await driveMeasuringPeak({ canned: baseCanned(g), args: { featureDir: '/f', maxConcurrency: cap } })
+    // Hardcoding 4 here would let a fixture with cap:2 and a broken cap of 4 pass green.
+    assert.equal(peak, cap, `maxConcurrency=${cap} but peak was ${peak}`)
+  }
+})
+
+test('#29: args.sequential runs one agent at a time', async () => {
+  const g = wideGraph(6)
+  const { peak, result } = await driveMeasuringPeak({ canned: baseCanned(g), args: { featureDir: '/f', sequential: true } })
+  assert.equal(peak, 1, `sequential must mean one in flight, got ${peak}`)
+  assert.ok(!result.halted, 'sequential must still complete the run')
+})
+
+test('#29: maxConcurrency 0 and -1 must not hang the run', async () => {
+  // MEASURED on the drafted design: `??` does not catch 0, `while (active >= 0)` is always true, and
+  // every agent blocks on its first acquire — 20 agents spawned, none completed, forever. The plan's
+  // own risk table called a hang "worse than crashing". `0` is how a user writes "unlimited".
+  for (const bad of [0, -1]) {
+    const g = wideGraph(4)
+    const done = await Promise.race([
+      driveMeasuringPeak({ canned: baseCanned(g), args: { featureDir: '/f', maxConcurrency: bad } }).then(() => 'completed'),
+      new Promise(r => setTimeout(() => r('HUNG'), 2000)),
+    ])
+    assert.equal(done, 'completed', `maxConcurrency=${bad} hung the run`)
+  }
+})
+
+test('#29: a non-numeric maxConcurrency must not delete the cap', async () => {
+  // MEASURED: `"abc"` makes `active >= "abc"` always false, the semaphore vanishes, and peak hit 20/20
+  // — the exact overload the cap exists to prevent, from a one-character typo. `args` is documented as
+  // possibly arriving JSON-encoded, so a string is live, not paranoia.
+  for (const bad of ['abc', null, {}, [], '4']) {
+    const g = wideGraph(8)
+    const { peak } = await driveMeasuringPeak({ canned: baseCanned(g), args: { featureDir: '/f', maxConcurrency: bad } })
+    assert.ok(peak <= 4 && peak > 0,
+      `maxConcurrency=${JSON.stringify(bad)} must fall back to the default cap, not remove it; peak was ${peak}`)
+  }
+})
+
+test('#29: a fractional maxConcurrency does not silently round up', async () => {
+  const g = wideGraph(8)
+  const { peak } = await driveMeasuringPeak({ canned: baseCanned(g), args: { featureDir: '/f', maxConcurrency: 2.5 } })
+  assert.equal(peak, 4, `2.5 is not an integer cap — it must be rejected for the default, not become 3; peak was ${peak}`)
+})
+
+// The throttle is asserted through the workflow's OWN log, not inferred from peak. Peak is the wrong
+// instrument here: the drop lands mid-fan-out, so agents already past acquire() still finish and the
+// observed peak reflects the cap *before* the drop. A racy fixture that infers it produces a test that
+// passes for the wrong reason — the first version of these two did exactly that.
+
+test('#29: the throttle drops concurrency to 1 after two terminal failures', async () => {
+  let nulls = 0
+  const g = wideGraph(8)
+  const { logs } = await driveMeasuringPeak({
+    canned: (label) => {
+      // Two agents the harness gives up on — a null means its own backoff is spent.
+      if (label.startsWith('verify:') && nulls < 2) { nulls++; return null }
+      return baseCanned(g)(label)
+    },
+  })
+  const drop = logs.find(l => /dropping concurrency to 1/i.test(l))
+  assert.ok(drop, `the throttle must fire and say so; logs were:\n  ${logs.join('\n  ')}`)
+  assert.match(drop, /2 terminal/i, 'the log must say how many failures tripped it, or it is unactionable')
+})
+
+test('#29: ONE terminal failure does NOT throttle — a single flake must not serialize a healthy run', async () => {
+  let nulls = 0
+  const g = wideGraph(8)
+  const { logs } = await driveMeasuringPeak({
+    canned: (label) => {
+      if (label.startsWith('verify:') && nulls < 1) { nulls++; return null }
+      return baseCanned(g)(label)
+    },
+  })
+  // The floor for the test above: without this, a throttle that fires on the FIRST failure also
+  // passes, and "2" would be decoration.
+  assert.ok(!logs.some(l => /dropping concurrency/i.test(l)),
+    'one terminal failure must not trip the throttle')
+})
+
+test('#29: retry exhaustion counts toward the throttle, not just a null return', async () => {
+  // The drafted design incremented `terminal` only on a null from agent(), so a run dying of repeated
+  // SCHEMA failures never tripped the throttle — and that is the symptom the field report actually
+  // describes ("completed without calling StructuredOutput", alongside 21 consecutive 529s). A throw
+  // that survives every retry is a terminal failure by any useful definition.
+  //
+  // Sequential fixture, deliberately: with [P] tasks retrying concurrently against a shared counter
+  // the throws scatter, every task can burn one and then succeed, and nothing is exhausted. The first
+  // version of this test did that and asserted a halt that never came.
+  const g = graph([{ name: 'Phase 1', tasks: [task('T001'), task('T002')] }])
+  const { logs } = await driveMeasuringPeak({
+    canned: (label) => {
+      if (label.startsWith('impl:')) throw new Error('completed without calling StructuredOutput')
+      return baseCanned(g)(label)
+    },
+  })
+  // Two implementers, each exhausting all 3 attempts => two terminal failures => throttle.
+  assert.ok(logs.some(l => /gave up after 3 attempts/i.test(l)), 'precondition: an implementer must exhaust its retries')
+  assert.ok(logs.some(l => /dropping concurrency to 1/i.test(l)),
+    `retry exhaustion must count as terminal; logs were:\n  ${logs.join('\n  ')}`)
+})
+
+test('#29: the effective cap is logged before the first implementer spawns', async () => {
+  const g = wideGraph(4)
+  const { logs, spawned } = await driveMeasuringPeak({ canned: baseCanned(g), args: { featureDir: '/f', maxConcurrency: 2 } })
+  const capLog = logs.findIndex(l => /concurrency/i.test(l) && /2/.test(l))
+  assert.ok(capLog >= 0, `the effective cap must be logged; logs were:\n  ${logs.join('\n  ')}`)
+  // An operator debugging an overloaded run needs to know what the cap actually was — after the fact
+  // is too late to be useful, and after the fan-out is after the damage.
+  assert.ok(!spawned.slice(0, 1).some(l => l?.startsWith('impl:')), 'cap must be known before implementers spawn')
+})
+
+test('#29: the regression lens no longer runs the full suite — the gate owns that', async () => {
+  const g = FIXTURES.twoPhasesSequential()
+  const prompts = {}
+  const kit = makeAgentStub(baseCanned(g))
+  const agent = async (p, o = {}) => { prompts[o.label] = p; return kit.agent(p, o) }
+  await makeRun(loadWorkflowSource())(agent, parallelThrowToNull, () => {}, () => {}, { featureDir: '/f' })
+
+  const lensPrompt = Object.entries(prompts).find(([k]) => k.startsWith('verify:T001:') && !k.includes('integrity') && !k.includes('requirement'))?.[1] ?? ''
+  assert.ok(!/FULL test suite|full test suite/i.test(lensPrompt),
+    'no verifier may run the full suite — 2 tasks meant 3 full suites where 1 would do')
+  assert.match(lensPrompt, /only this task|own test file/i,
+    'the lens must be told to run only the task\'s own test')
+})
+
+test('#29: ...and the phase gate STILL runs it — the pair is the invariant', async () => {
+  // The half that makes the previous test meaningful. "No lens runs the suite" passes vacuously if
+  // the suite check is DELETED rather than MOVED: no lens asks, no gate asks, nothing runs the tests,
+  // and both assertions are green. Neither half is the invariant; the pair is.
+  const g = FIXTURES.twoPhasesSequential()
+  let gatePrompt = ''
+  const kit = makeAgentStub(baseCanned(g))
+  const agent = async (p, o = {}) => { if (o.label?.startsWith('gate:')) gatePrompt = p; return kit.agent(p, o) }
+  await makeRun(loadWorkflowSource())(agent, parallelThrowToNull, () => {}, () => {}, { featureDir: '/f' })
+  assert.match(gatePrompt, /Full test suite/,
+    'the gate must still own the full-suite check — if it is gone from both, nothing runs the suite at all')
+})
+
 test('SC-017: a done:true task is excluded from total, and an unreached phase is notAttempted', async () => {
   const g = FIXTURES.twoPhases()
   const { result } = await drive({

--- a/workflows/speckit-workflow.js
+++ b/workflows/speckit-workflow.js
@@ -161,9 +161,15 @@ inputs rather than implementing the general rule.`,
   },
   {
     key: 'regression',
-    ask: `Run the FULL test suite yourself. Refute if anything outside this task's own test
-is now failing, or if the suite cannot run. Do not take the implementer's word for
-it — the implementer reporting green is a claim, not evidence.`,
+    ask: `Run ONLY this task's own test file — the one reported above — and nothing else. Do NOT run
+the full suite: the phase gate owns the whole-suite regression check, and it runs once per
+phase. Refute if that test does not pass, cannot run, or does not exist. Do not take the
+implementer's word for it — the implementer reporting green is a claim, not evidence.
+
+Why the narrow scope: this lens used to run the whole suite, so a 2-task phase ran three
+full suites (two lenses plus the gate) where one would do. On a 728-test, ~12-minute suite
+that is what tripped the shared rate limit, and the retries then added load of their own.
+Cross-task regression is still caught — at the phase barrier, before anything depends on it.`,
   },
 ]
 
@@ -194,15 +200,27 @@ function keyOf(pi, ti) {
 // reachability is unknown and the hedge costs two characters.
 async function agentTyped(prompt, opts, tries = 2) {
   for (let i = 0; ; i++) {
+    await acquire()
     try {
-      return await agent(prompt, opts)
+      const r = await agent(prompt, opts)
+      if (r === null) noteTerminal(opts?.label)
+      return r
     } catch (e) {
       const why = e?.message ?? String(e)
       if (i >= tries) {
         log(`${opts?.label}: gave up after ${tries + 1} attempts — ${why}`)
+        // Retry exhaustion IS a terminal failure. Counting only the harness's null was the drafted
+        // design's blind spot: a run dying of repeated schema failures would never have tripped the
+        // throttle, and that is the symptom under load.
+        noteTerminal(opts?.label)
         return null
       }
       log(`${opts?.label}: retry ${i + 1}/${tries} — ${why}`)
+    } finally {
+      // `finally`, so the permit is returned on ALL THREE paths: success, give-up, and the
+      // fall-through that loops round to retry. A leak here would shrink the cap toward zero and
+      // stall the run — the hang the validation above exists to prevent, arriving by another door.
+      release()
     }
   }
 }
@@ -319,6 +337,79 @@ if (typeof _args === 'string') {
 }
 const requestedDir =
   typeof _args === 'string' ? _args : (_args && _args.featureDir) || ''
+// --- the concurrency cap ------------------------------------------------------------------------
+//
+// Measured, on a 2-task graph: 12 agents, peak 6. The harness caps at min(16, cores-2), which is a
+// CPU bound and says nothing about a shared API — so a single phase put a dozen agents in flight,
+// several driving a 12-minute suite, and the run self-inflicted sustained 429/529. One verifier hit
+// 529 twenty-one times. The retries then added load of their own.
+//
+// The cap lives here because this is the one function every spawn passes through. Chunking each
+// fan-out separately would not work: the verifier fan-out NESTS inside the batch fan-out, so a cap of
+// 4 per level is 16 in flight. Gating at the choke point is what makes the cap global.
+//
+// VALIDATE. This is A's first argument surface, and `args` is documented as possibly arriving
+// JSON-encoded, so the value is whatever the caller put there. Measured on the drafted design:
+// `0`/`-1` hang the run forever having spawned nothing (`??` does not catch 0, and `while (active >= 0)`
+// never lets anyone through — while `0` is exactly how a user writes "unlimited"); `"abc"` deletes the
+// cap entirely, peak 20/20, because `active >= NaN` is always false; `2.5` silently becomes 3.
+const DEFAULT_CONCURRENCY = 4
+const _capArg = Number(_args?.maxConcurrency)
+if (_args?.maxConcurrency !== undefined && !(Number.isInteger(_capArg) && _capArg > 0)) {
+  log(`ignoring args.maxConcurrency: ${JSON.stringify(_args.maxConcurrency)} is not a positive integer — using ${DEFAULT_CONCURRENCY}`)
+}
+let limit = _args?.sequential
+  ? 1
+  : Number.isInteger(_capArg) && _capArg > 0
+    ? _capArg
+    : DEFAULT_CONCURRENCY
+
+let active = 0
+let terminal = 0
+const waiters = []
+
+// `while`, not `if`: the limit can DROP mid-run (see the throttle below), so a woken waiter must
+// re-check rather than assume a permit is free. The algorithm survived adversarial attack — no lost
+// wakeup, no starvation at 200 arrivals, balanced accounting across the retry path. It is not the part
+// that was ever broken; the input validation above is.
+async function acquire() {
+  while (active >= limit) await new Promise(r => waiters.push(r))
+  active++
+}
+const release = () => {
+  active--
+  waiters.shift()?.()
+}
+
+// A terminal failure is an agent we could not get an answer from after exhausting our retries — a null
+// from the harness (its own backoff is spent) OR a throw that survived all attempts. Counting only the
+// null was the drafted design's gap: a run dying of repeated schema failures never tripped the
+// throttle, and "completed without calling StructuredOutput" under load is the symptom the field
+// report actually describes.
+//
+// Two, not one: a single flake should not serialize a healthy run; two suggests the API is genuinely
+// hot. A slow sequential finish beats a fast failure.
+// Say the cap out loud, before anything fans out. An operator debugging an overloaded run needs to
+// know what the limit actually was, and learning it after the fan-out is learning it after the damage.
+log(
+  _args?.sequential
+    ? 'concurrency: 1 (args.sequential)'
+    // Say "agents in flight" — never the singular followed by a parenthesised plural. That spelling
+    // reads as an unwrapped spawn to the smoke guard and reddens CI on correct code. (This comment
+    // is deliberately periphrastic for the same reason: naming the bad spelling would BE the bad
+    // spelling. Reword prose; never loosen the guard.)
+    : `concurrency: ${limit} agents in flight${limit === DEFAULT_CONCURRENCY && _args?.maxConcurrency === undefined ? ' (default — pass args.maxConcurrency to change it)' : ''}`,
+)
+
+const THROTTLE_AT = 2
+function noteTerminal(label) {
+  terminal++
+  if (terminal >= THROTTLE_AT && limit > 1) {
+    limit = 1
+    log(`API looks hot (${terminal} terminal agent failures) — dropping concurrency to 1 for the rest of the run`)
+  }
+}
+
 
 const ctx = await agentTyped(
   `Load the spec-kit artifacts for the current feature.


### PR DESCRIPTION
Closes #29 — feature **B** of the FxCube #314 field report. C (#30) remains.

## Measured, before and after

The harness caps concurrency at `min(16, cores-2)` — a **CPU** bound that says nothing about a **shared API**. So a single phase put a dozen agents in flight, several driving a 12-minute suite, and the run self-inflicted sustained 429/529. One verifier hit 529 **twenty-one times** before the run died.

Same 2-task fixture Spike 3 measured:

```
BEFORE                        agents=12  peak=6  full-suite prompts=6
AFTER (#29)                   agents=12  peak=4  full-suite prompts=4
AFTER, args.maxConcurrency=2  agents=12  peak=2  full-suite prompts=4
AFTER, args.sequential        agents=12  peak=1  full-suite prompts=4
```

Agent **count** is unchanged, and should be — this caps how many run *at once* and how many drive a whole suite. Reducing the count is a different feature.

## The algorithm was never the broken part

The adversarial review already validated it — no lost wakeup, no starvation at 200 arrivals, balanced accounting across the retry path, correct under drop-to-1 and nested fan-out. **The input validation was:**

| input | before | now |
|---|---|---|
| `0` / `-1` | **hung forever**, zero agents spawned. `??` doesn't catch `0` — and `0` is how a user writes "unlimited" | falls back to the default, logged |
| `"abc"` | **cap deleted**, measured peak 20/20 (`active >= NaN` is always false). `args` can arrive JSON-encoded, so a string is live | falls back, logged |
| `2.5` | silently became 3 | falls back, logged |

The cap lives in `agentTyped` because that's the one function every spawn passes through. Chunking each fan-out separately fails: the verifier fan-out **nests** inside the batch fan-out, so 4-per-level is 16 in flight.

## Throttle

Drops to 1 after **two** terminal failures — one flake shouldn't serialize a healthy run; two suggests the API is genuinely hot. **Retry exhaustion counts as terminal**, not just a null from the harness: counting only the null was the drafted design's blind spot, and a run dying of repeated *"completed without calling StructuredOutput"* is the symptom the field report actually describes.

## The lens/gate pair

The regression lens now runs only the task's own test file; the gate still owns the whole-suite check. **Both halves are tested** — "no lens runs the suite" passes vacuously if the check is *deleted* rather than *moved*, so neither half is the invariant on its own.

## File length

The 500-line limit is now **scoped to exclude this one file**, with the reason on record: the Workflow harness executes the script as a *function body*, so a static `import` is a **compile error** — verified, not assumed (`require` is undefined; dynamic `import()` isn't something the plugin's core may bet on given the docs disclaim Node API access). **The limit's remedy — "split the file" — does not exist here.** Every other file keeps it. The alternative was deleting comments that each record a measured defect, which keeps the complexity and loses the reason nobody reintroduces it.

## Verification

```
node --test      53 pass, 0 fail   (13 new, RED first)
tests/smoke.sh   48 passed, 0 failed
spawns           1 (choke point holds)
```

**All 7 mutations executed and fire.** Notes for whoever touches this next:

- `assert.ok(peak <= cap)` is a **ceiling with no floor** — it passes *more easily the more broken the file is*. These use `strictEqual` against the cap **the test passed in**, on a fixture whose *unbounded* peak exceeds it.
- The throttle is asserted through the workflow's **own log**, not inferred from peak — the drop lands mid-fan-out, so peak reflects the cap *before* it. The first version inferred it and passed for the wrong reason.
- A **"one terminal failure must NOT throttle"** test exists so `THROTTLE_AT = 2` is load-bearing rather than decorative.

## Found while doing this: #38

`implPrompt` step 3 tells **every implementer** to run the full suite — a **third** amplitude source #29 never named. True amplitude was `2N+1` suites per phase; this takes it to `N+1`, not 1. Filed as **#38** rather than folded in, because removing step 3 changes the TDD cycle itself and deserves its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)