### PR TITLE
fix: the implementer confirms its own test, not the full suite (#38)

### DIFF
--- a/tests/workflow.test.js
+++ b/tests/workflow.test.js
@@ -946,6 +946,38 @@ test('#29: the effective cap is logged before the first implementer spawns', asy
   assert.ok(!spawned.slice(0, 1).some(l => l?.startsWith('impl:')), 'cap must be known before implementers spawn')
 })
 
+test('#38: the implementer confirms its OWN test and does not run the full suite — the gate owns that', async () => {
+  // Step 3 used to tell every implementer to run the whole suite, so a phase of N tasks ran N full
+  // suites from implementers alone (plus the gate). #29 fixed the concurrency overload; this removes
+  // the redundant volume. The phase gate already runs the whole suite per repo and catches any
+  // regression the implementer's run would — same dedup #29 applied to the lens, one layer up.
+  const g = FIXTURES.twoPhasesSequential()
+  const { prompts } = await driveCapturing({ canned: baseCanned(g) })
+  const impl = prompts['impl:T001']
+  assert.ok(!/full (test )?suite/i.test(impl),
+    'the implementer must NOT be told to run the full suite — that is the phase gate\'s job now')
+  assert.match(impl, /own test|the phase gate/i,
+    'it must confirm its own test and be told the gate owns whole-suite regression')
+})
+
+test('#38: only the GATE is told to RUN the full suite now — not the implementer, not the lenses', async () => {
+  // The invariant after narrowing: exactly one KIND of agent is instructed to RUN the full suite — the
+  // gate. This is the pair to #38's narrowing: "implementer does not run it" passes vacuously if the
+  // whole-suite check vanished everywhere, so assert the gate STILL does.
+  //
+  // The loader is excluded deliberately: its job is to DETECT "the command that runs the full test
+  // suite", so it names the phrase without running anything. Detecting the command and running the
+  // suite are different acts; only the second is what amplitude counts.
+  const g = FIXTURES.twoPhasesSequential()
+  const { prompts } = await driveCapturing({ canned: baseCanned(g) })
+  const runsSuite = Object.entries(prompts)
+    .filter(([l]) => l !== 'load-artifacts')
+    .filter(([, p]) => /Full test suite \(`/.test(p) || /run the full (test )?suite/i.test(p))
+    .map(([l]) => l.replace(/:.*/, ''))
+  const kinds = [...new Set(runsSuite)]
+  assert.deepEqual(kinds, ['gate'], `only the gate may be told to RUN the full suite; got: ${runsSuite.join(', ')}`)
+})
+
 test('#29: the regression lens no longer runs the full suite — the gate owns that', async () => {
   const g = FIXTURES.twoPhasesSequential()
   const prompts = {}

--- a/workflows/speckit-workflow.js
+++ b/workflows/speckit-workflow.js
@@ -292,8 +292,11 @@ The cycle, in this order:
             fail, and fail for the RIGHT reason (not an import error or a typo). If it
             passes already, the test is not testing new behavior — rewrite it.
  2. GREEN — write the minimum code to make it pass. Run the test again.
- 3. SUITE — run the full test suite. No regressions. If something else broke, fix the
-            IMPLEMENTATION. Never edit another test to make it pass.
+ 3. CONFIRM — re-run THIS task's own test and confirm it still passes. Do NOT run the full
+            suite: the phase gate runs it once per repo and owns whole-suite regression, so N
+            implementers all running it is wasted work. If your change broke something outside
+            this task, the gate catches it — and the fix is always the IMPLEMENTATION, never a
+            weakened test.
 
 Hard rules:
  - Touch ONLY the files this task needs. Other tasks are running in parallel on other files.


### PR DESCRIPTION
Closes #38 — the third full-suite source #29 never named.

`implPrompt` step 3 told **every implementer** to run the whole suite, so a phase of N tasks ran **N full suites from implementers alone**, plus the gate. #29 fixed the concurrency **overload** (429/529, now ≤4 in flight); this removes the redundant **volume**.

## The change

Step 3 now re-runs only the **task's own test** to confirm GREEN. The phase gate already runs the whole suite once per repo and owns whole-suite regression — so it catches anything an implementer's run would. And for a `[P]` task the mid-batch full-suite run was **unreliable anyway**: other implementers are still mutating the tree.

Same dedup #29 applied to the regression lens, one layer up:

| agent | runs |
|---|---|
| task-tests lens | the task's own test |
| implementer (now) | the task's own test |
| **phase gate** | **the whole suite, once per repo** |

## Measured

```
3 tasks / 1 phase:  full-suite RUN instructions  4 -> 1   (N+1 collapses to the gate alone)
```

## Cost, accepted

A regression surfaces at the phase gate (phase granularity) rather than per-task. The gate is authoritative, all tasks are complete when it runs, and per-task attribution in a `[P]` batch was already muddy.

## Verification

```
node --test      67 pass, 0 fail   (2 new, RED first)
tests/smoke.sh   48 passed, 0 failed
```

**The pair is the invariant:** "the implementer does not run the suite" passes vacuously if the whole-suite check vanished *everywhere*, so the second test asserts the **gate still runs it**. The loader is excluded from that check deliberately — it *detects* "the command that runs the full test suite" without running anything, and detecting the command is a different act from running the suite (that distinction was itself a false-positive the second test caught before I tightened it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)