### PR TITLE
fix: stop Stop-hook from timing out on large repos

### DIFF
--- a/hooks/stop-quality-check.sh
+++ b/hooks/stop-quality-check.sh
@@ -13,24 +13,19 @@ if [ "$CWD" = "$HOME" ] || [ "$CWD" = "/" ]; then
   exit 0
 fi
 
-# Check if any source files were recently modified (last 60 seconds)
-# This approximates "did Claude edit code during this turn"
-# Process substitution (not a pipeline) avoids a SIGPIPE race that would
-# otherwise combine with `pipefail` + `set -e` to abort the script silently.
-RECENT_EDITS=""
-NOW=$(date +%s)
-while IFS= read -r f; do
-  if [ -f "$f" ]; then
-    MTIME=$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || echo 0)
-    if [ $((NOW - MTIME)) -lt 60 ]; then
-      RECENT_EDITS="$f"
-      break
-    fi
-  fi
-done < <(find "$CWD" -maxdepth 5 \
-  \( -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" \
-  -o -name "*.py" -o -name "*.rs" -o -name "*.go" \) \
-  2>/dev/null)
+# Find the first source file modified in the last minute (≈ "did Claude edit
+# code this turn"). Prune heavy dirs (node_modules/.venv/.git/build) so the walk
+# stays cheap in large monorepos, and let `find` do the mtime test and quit on
+# the first hit. The old version forked `stat` per matched file — ~11.7k forks /
+# ~9s in a multi-service repo, which blew the 10s Stop-hook timeout (207/248
+# stops timed out); it also false-fired on node_modules churn, which is not
+# Claude editing code.
+RECENT_EDITS=$(find "$CWD" -maxdepth 5 \
+  \( -type d \( -name node_modules -o -name .venv -o -name venv -o -name .git \
+     -o -name target -o -name dist -o -name build -o -name __pycache__ \) -prune \) \
+  -o \( -type f \( -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" \
+     -o -name "*.py" -o -name "*.rs" -o -name "*.go" \) -mmin -1 -print -quit \) \
+  2>/dev/null || true)
 
 if [ -z "$RECENT_EDITS" ]; then
   exit 0

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -153,6 +153,46 @@ while read -r cmd; do
   else ok "hook $name exists and is executable"; fi
 done < <(jq -r '.hooks | to_entries[] | .value[] | .hooks[] | .command' "$REPO/hooks/hooks.json")
 
+# --- Tier 1: stop hook (Stop-timeout regression) ------------------------------------
+head_ "Stop hook"
+
+# stop-quality-check.sh once walked the tree and forked `stat` per matched file —
+# ~11.7k forks / ~9s in a monorepo, timing out the 10s Stop hook on 207/248 stops.
+# The fix prunes heavy dirs and lets `find` do the mtime test with -mmin/-print/-quit.
+# Guard the mechanism AND the behaviour so the stat loop cannot return unnoticed.
+SQC="$REPO/hooks/stop-quality-check.sh"
+sqc_src="$(cat "$SQC")"
+if grep -qF -- '-mmin' <<<"$sqc_src" && grep -qF -- '-prune' <<<"$sqc_src" && grep -qF -- '-print -quit' <<<"$sqc_src"; then
+  ok "stop hook uses pruned find with -mmin/-print -quit"
+else
+  bad "stop hook lost its pruned -mmin/-quit find — the O(files) stat loop can reappear"
+fi
+if grep -qF 'stat -c %Y' <<<"$sqc_src"; then
+  bad "stop hook still forks 'stat' per file — the Stop-timeout regression is back"
+else
+  ok "stop hook no longer forks stat per file"
+fi
+
+# Behaviour: a recent edit inside node_modules must NOT fire the reminder (the old,
+# unpruned find did); a recent real source edit MUST. Fresh temp dir → no test stamp.
+sqc_t="$(mktemp -d)"
+mkdir -p "$sqc_t/src" "$sqc_t/node_modules/pkg"
+touch "$sqc_t/node_modules/pkg/recent.js"
+out_junk="$(printf '{"cwd":"%s"}' "$sqc_t" | bash "$SQC" 2>&1)"
+if grep -qi 'tests haven' <<<"$out_junk"; then
+  bad "stop hook false-fires on node_modules churn (prune not applied)"
+else
+  ok "stop hook ignores node_modules churn"
+fi
+touch "$sqc_t/src/new.py"
+out_src="$(printf '{"cwd":"%s"}' "$sqc_t" | bash "$SQC" 2>&1)"
+if grep -qi 'tests haven' <<<"$out_src"; then
+  ok "stop hook still reminds on a recent source edit"
+else
+  bad "stop hook no longer detects a recent source edit"
+fi
+rm -rf "$sqc_t"
+
 # --- Tier 1: the #7 regression guard ------------------------------------------------
 head_ "Command → helper wiring"
 


### PR DESCRIPTION
## Problem

`hooks/stop-quality-check.sh` (the `Stop` hook, 10s timeout) hangs on large repos. `/doctor` surfaced it: **207 of 248 stops in one 50-session window hit the 10s timeout** — up to ~10s of dead time after most responses.

## Root cause (measured, not assumed)

The hook walked the tree and forked `stat` **once per matched source file**. The `find` didn't prune `node_modules`/`.venv`/`.git`/`build`, so a multi-service monorepo yields **~11,700 candidates** (11,094 of them junk) → ~11,700 sequential `stat` forks.

| | files | time |
|---|---|---|
| hook end-to-end on a real monorepo | — | **8.95s** (idle; >10s under session load) |
| the `stat` loop alone | 11,671 | 7.1s |
| same hook on a small repo | 2 | 13ms |

That's why 41 runs completed (small repos) and the median pinned at ~10,005ms (big repos).

## Fix

Replace the `stat` loop with a single pruned `find … -mmin -1 -print -quit`: prune heavy dirs, let `find` do the mtime test, quit on the first hit.

- **8.95s → 6ms** on the same monorepo.
- Also fixes a latent **false positive**: the old unpruned find fired the "tests weren't run" reminder on plain `node_modules` churn (e.g. after `npm install`), which isn't Claude editing code.

## Tests

Adds a "Stop hook" guard to `tests/smoke.sh` — mechanism (pruned `-mmin`/`-print -quit`, no `stat` fork) **and** behavior (ignores `node_modules` churn, still reminds on a real recent edit). Mutation-proven: reverting the hook to the old version fails 3 of the 4 guards; the 4th (real-edit detection) stays green as a floor. Suite: **52 passed, 0 failed.**

## Deployment note

The live hook runs from the installed plugin copy, so this needs to merge and the plugin be updated for running sessions to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)