### PR TITLE
feat: hard-deny destructive commands and add /adf.sync drift check

### DIFF
--- a/.claude/rules/llm-security.md
+++ b/.claude/rules/llm-security.md
@@ -24,6 +24,7 @@ Agent takes actions beyond what the user intended — especially destructive or 
 - Follow Core Rule #1: "Do what has been asked; nothing more, nothing less"
 - Existing safeguard: `block-sensitive-files.sh` blocks writes to `.env`, `.key`, `.pem`, credentials, secrets directories
 - Never run destructive git commands (`push --force`, `reset --hard`, `branch -D`) without explicit user request
+- Enforced: `block-destructive-commands.sh` hard-denies those commands (plus `git clean -f` and recursive `rm` of catastrophic targets) at the PreToolUse layer; when the user explicitly requests one, prefix it with `CLAUDE_ALLOW_DESTRUCTIVE=1` — the bypass stays visible in the transcript
 - Prefer read-only operations during exploration and analysis phases
 - When uncertain about scope, ask the user rather than assuming broader permissions
 - Limit tool permissions to what the current task requires
@@ -62,7 +63,7 @@ The framework uses layered defenses — no single mechanism is sufficient:
 
 | Layer | Mechanism | Example |
 |-------|-----------|---------|
-| **Enforcement** | Hooks (automated, deterministic) | `block-sensitive-files.sh`, `quality-before-commit.sh` |
+| **Enforcement** | Hooks (automated, deterministic) | `block-sensitive-files.sh`, `block-destructive-commands.sh`, `quality-before-commit.sh` |
 | **Guidance** | Rules (context for agent reasoning) | This file, `code-quality.md` |
 | **Analysis** | Skills and agents (deep review) | built-in `/security-review`, `/adf.security-scan` command, `forensic-specialist` agent |
 | **Validation** | Quality gates (pre-integration) | `quality-guardian` agent, `/adf.quality` command |

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ an upgrade — see [`docs/install.md`](docs/install.md).
 
 | Directory | What lives there |
 |---|---|
-| 🛠️ `commands/` | The 18 slash commands. All namespaced (`adf.*`, `speckit.*`) so no built-in can shadow them. |
+| 🛠️ `commands/` | The 19 slash commands. All namespaced (`adf.*`, `speckit.*`) so no built-in can shadow them. |
 | 🕵️ `agents/` | Six specialist subagents — testing, quality, review, security, PR coordination, recon. |
 | ⚙️ `hooks/` | Nine hooks, plus `speckit-helper.sh` (34 subcommands) that the commands call for live git data. |
 | 🧠 `skills/` | Systematic debugging, effort estimation, performance audit, plus reference skills promoted from rules (quality tooling, pipeline & MCP security, agent collaboration). |
@@ -185,7 +185,7 @@ The hooks ship with the plugin — you do not register them:
 | | |
 |---|---|
 | 📦 [Installing & Configuring](docs/install.md) | Install, the permission rule, verification, updating, what the plugin cannot ship. |
-| 🛠️ [Commands](docs/commands.md) | All 18, with arguments. |
+| 🛠️ [Commands](docs/commands.md) | All 19, with arguments. |
 | 🕵️ [Agents & Parallelism](docs/agents.md) | The six agents; when to use a subagent vs. a team vs. a workflow. |
 | ⚙️ [Hooks & Quality Gates](docs/hooks.md) | Every hook, the Iron Laws, and the security posture. |
 | 🧬 [Spec-Driven Development](docs/spec-kit.md) | The lifecycle in depth, `.specify/` artifacts, task management. |

--- a/commands/adf.sync.md
+++ b/commands/adf.sync.md
@@ -1,0 +1,70 @@
+---
+description: "Check the three framework copies (installed plugin, global rules, upstream) are in sync"
+---
+
+Three copies of this framework exist on a machine, and a change to one is inert in the others
+until deliberately propagated. Report whether they agree. This command **reports only** — it
+proposes remediation commands but never runs them without the user's say-so.
+
+The three copies:
+
+1. **Upstream** — `origin/main` of the framework repository (source of truth).
+2. **Installed plugin clone** — the directory the marketplace install points at (the live
+   hooks, skills, commands, and agents run from here). Its path is the plugin root this
+   command itself loaded from.
+3. **Global rules** — `~/.claude/rules/*.md` (often stow-symlinked from a dotfiles repo).
+   These are NOT plugin payload; they are hand-synced and drift silently.
+
+## Check Steps
+
+> The commands below must be run with the Bash tool; they cannot be pre-executed in a
+> `!` block. A `!` block is permission-checked before the CLAUDE_PLUGIN_ROOT variable is
+> substituted, so it is rejected as "Contains expansion".
+
+### 1. Locate the installed clone
+
+Run with the Bash tool: `git -C "${CLAUDE_PLUGIN_ROOT}" rev-parse --show-toplevel 2>/dev/null || echo NOT-A-GIT-CLONE`
+
+If the result is `NOT-A-GIT-CLONE`, the plugin was installed from a plain directory copy —
+report that staleness cannot be measured and skip to step 3.
+
+### 2. Installed clone vs upstream
+
+Run with the Bash tool (fetch is read-only):
+
+- `git -C "${CLAUDE_PLUGIN_ROOT}" fetch --quiet origin`
+- `git -C "${CLAUDE_PLUGIN_ROOT}" rev-list --count HEAD..origin/main` → commits **behind**
+- `git -C "${CLAUDE_PLUGIN_ROOT}" status --porcelain` → local modifications (should be none)
+
+### 3. Global rules vs upstream
+
+Compare each `~/.claude/rules/*.md` against the same file at `origin/main` — via
+`git -C "${CLAUDE_PLUGIN_ROOT}" show origin/main:.claude/rules/<file>` piped to
+`diff - ~/.claude/rules/<file>` (or `HEAD:` if step 1 said the clone has no remote).
+Also list files present on one side only, and report `readlink ~/.claude/rules` /
+`readlink ~/.claude/rules/<file>` so the user can see whether stow manages them.
+
+## Output Format
+
+```
+FRAMEWORK SYNC REPORT
+=====================
+Installed clone: [path] — [in sync | N commits behind origin/main | locally modified | not a git clone]
+Global rules:    [N/N identical | list of differing/missing files]
+Stow-managed:    [yes → dotfiles target | no — plain files]
+
+Remediation (propose, do not run):
+  [only the commands the findings actually call for]
+```
+
+## Remediation Rules
+
+- Clone behind → propose `git -C <clone> pull --ff-only` and remind the user that a Claude
+  Code restart is required before the updated hooks/skills load.
+- Rules differ → propose copying the upstream version **into the dotfiles target** (follow
+  the readlink), or the reverse if the local edit is the intended one — ask, don't guess.
+- **Never `mv` onto a path under `~/.claude/`** — if the path is a stow symlink, `mv`
+  replaces the symlink with a regular file and the dotfiles repo silently stops receiving
+  updates. Use `cp` (which writes *through* the symlink) or edit the dotfiles file directly.
+- Local modifications in the installed clone are a red flag: edits there are overwritten by
+  the next pull. Propose moving them to the dev repo as a PR instead.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ ai-assisted-development-framework/
 │   └── marketplace.json        # makes the repo installable (`claude plugin install`)
 ├── .mcp.json                   # GitHub MCP server (project scope)
 ├── agents/                     # 6 agents (5 pipeline + repo-scout one-shot)
-├── commands/                   # 18 slash commands (5 adf.* + 13 speckit.*)
+├── commands/                   # 19 slash commands (6 adf.* + 13 speckit.*)
 ├── hooks/                      # 9 hooks + hooks.json + speckit-helper.sh
 ├── skills/                     # 7 skills, each a <name>/SKILL.md directory
 ├── workflows/                  # speckit-workflow.js — the deterministic task-list executor

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -11,6 +11,7 @@
 | `/adf.pr-summary` | — | Generate PR description from current branch diff |
 | `/adf.quality` | — | Run comprehensive quality checks (spawns quality-guardian) |
 | `/adf.security-scan` | — | Scan staged changes for secrets, SQLi, XSS |
+| `/adf.sync` | — | Report drift between the installed plugin clone, the global rules, and upstream |
 | `/speckit.init` | — | Bootstrap `.specify/` directory in current project |
 | `/speckit.constitution` | — | Create/update project governance principles |
 | `/speckit.brainstorm` | `<idea>` | Socratic design exploration before specification |

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -12,6 +12,7 @@ Hooks ship **inside the plugin** (`hooks/hooks.json`), so installing the plugin 
 | ✅ `verify-before-task-complete.sh` | **TaskCompleted** | **Blocks** a task from being marked complete while the test suite fails. Exit 2 is a hard gate. |
 | 🔍 `quality-before-commit.sh` | PreToolUse on `Bash` | Intercepts `git commit` — gitleaks, shell + markdown checks on staged files, then language-specific linters. Blocks on errors. |
 | 🔒 `block-sensitive-files.sh` | PreToolUse on `Edit\|Write` | Blocks writes to `.env*`, `*.key`, `*.pem`, `credentials*`, `.git/*`, `secrets/` |
+| ⛔ `block-destructive-commands.sh` | PreToolUse on `Bash` | Hard-denies `git push --force` (allows `--force-with-lease`), `reset --hard`, `branch -D`, `clean -f`, and recursive `rm` of catastrophic targets. Bypass: `CLAUDE_ALLOW_DESTRUCTIVE=1` prefix, visible in the transcript |
 | 📐 `plan-phase-write-block.sh` | PreToolUse on `Edit\|Write` | Blocks writes outside `.specify/` while `/speckit.plan` is active |
 | 🎨 `format-after-edit.sh` | PostToolUse on `Edit\|Write` | Auto-formats edited files (ruff, biome/prettier, gofmt, rustfmt), 10s throttle |
 | 🧪 `run-tests-after-edit.sh` | PostToolUse on `Edit\|Write` | Auto-runs test suite after source edits, 15s throttle, non-blocking |
@@ -56,10 +57,11 @@ It is the enforcement the Verification Iron Law always claimed to have:
 
 ## 🛡️ Automated Quality Gates
 
-Eight hooks enforce quality automatically — and they ship with the plugin, so there is nothing to register:
+Nine hooks enforce quality automatically — and they ship with the plugin, so there is nothing to register:
 
 - 🔍 **Pre-commit** — secrets detection (gitleaks) + language-specific linting blocks the commit on errors
 - 🔒 **File protection** — writes to `.env`, `*.key`, `*.pem`, credentials, and `.git/` internals are blocked
+- ⛔ **Destructive-command denials** — `git push --force`, `reset --hard`, `branch -D`, `clean -f`, and recursive `rm` of catastrophic targets are hard-denied at the PreToolUse layer. The llm-security rule always said "never without explicit user request"; this is the mechanism behind the prose, with a transcript-visible bypass (`CLAUDE_ALLOW_DESTRUCTIVE=1`) for when the user *does* request it
 - 🎨 **Auto-format** — formatters run after every edit (ruff, biome, gofmt, rustfmt)
 - 🧪 **Auto-test** — test suite runs after source file edits (throttled 15s, non-blocking)
 - 📊 **Reminders** — alerts if source files were edited but tests weren't run
@@ -75,7 +77,7 @@ The framework implements layered defenses against OWASP LLM vulnerabilities:
 
 | Layer | Mechanism | Covers |
 |-------|-----------|--------|
-| **Enforcement** | Hooks | Sensitive file blocking, secrets detection, pre-commit quality |
+| **Enforcement** | Hooks | Sensitive file blocking, destructive-command denials, secrets detection, pre-commit quality |
 | **Guidance** | Rules | OWASP LLM Top 10, MCP security, code quality, SOLID principles |
 | **Analysis** | Skills & Agents | Built-in `/security-review`, `/adf.security-scan`, forensic investigation, quality gates |
 | **Efficacy** | Iron Laws | Verification before completion (rule + `TaskCompleted` hook), systematic-debugging |

--- a/hooks/block-destructive-commands.sh
+++ b/hooks/block-destructive-commands.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+set -euo pipefail
+
+# PreToolUse gate on Bash: hard denials for destructive commands.
+#
+# llm-security.md has always SAID "never run push --force / reset --hard / branch -D
+# without explicit user request" — but prose is guidance the model can rationalize past,
+# and the framework's own thesis (Defense in Depth) is that prompting is not a mechanism.
+# This hook is the mechanism. Pattern borrowed from YC's QM harness, whose command policy
+# hard-denies recursive deletes in every security posture.
+#
+# Threat model: a CARELESS or prompt-injected agent typing the destructive command in its
+# obvious form. It is not a sandbox — a determined adversary can compose around a string
+# match (bash -c, variables). That evasion is visible in the transcript, which is the
+# same auditability bet CLAUDE_SKIP_VERIFY_GATE makes.
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+[ -z "$CMD" ] && exit 0
+
+# Visible, auditable bypass for when the USER explicitly requested the command — the
+# "explicit user request" clause of llm-security.md, made mechanical. The prefix lives in
+# the command string, so using it is always on the record. Mirrors CLAUDE_SKIP_VERIFY_GATE.
+if [[ "$CMD" == *"CLAUDE_ALLOW_DESTRUCTIVE=1"* ]]; then
+  exit 0
+fi
+
+deny() {
+  echo "Blocked: $1" >&2
+  echo "This is a hard denial (block-destructive-commands.sh). If the user explicitly asked for this exact command, re-run it prefixed with CLAUDE_ALLOW_DESTRUCTIVE=1 — the bypass stays visible in the transcript. Otherwise ask the user first." >&2
+  exit 2
+}
+
+# Heredoc bodies are data, but sed's quote-stripping below is line-based and cannot see a
+# quote span that crosses lines — so a commit-message heredoc mentioning "git reset --hard"
+# was denied (measured, not imagined: this repo's own commit style is `-m "$(cat <<'EOF'`).
+# Drop everything between a `<<WORD` opener and the WORD terminator line before analysing.
+CMD=$(printf '%s\n' "$CMD" | awk '
+  h { if ($0 == term) h = 0; next }
+  match($0, /<<-?[[:space:]]*["'\'']?[A-Za-z_][A-Za-z0-9_]*/) {
+    term = substr($0, RSTART, RLENGTH)
+    sub(/<<-?[[:space:]]*["'\'']?/, "", term)
+    h = 1; print; next
+  }
+  { print }')
+
+# Two-step normalisation, order load-bearing:
+#   1. UNQUOTE whitespace-free quoted tokens — "$HOME" must stay matchable as a target.
+#   2. DELETE remaining quoted spans — they contain whitespace, i.e. prose. Without this,
+#      `git commit -m "docs: never git reset --hard"` is denied: data read as command.
+#      (Committing THIS feature would trip its own hook — that false positive is real.)
+NORM=$(printf '%s' "$CMD" | sed -E \
+  -e 's/"([^"[:space:]]*)"/\1/g' \
+  -e "s/'([^'[:space:]]*)'/\1/g" \
+  -e 's/"[^"]*"//g' \
+  -e "s/'[^']*'//g")
+
+has_word() { [[ "$1" =~ (^|[[:space:]])$2([[:space:]]|$) ]]; }
+
+check_git_segment() {
+  local seg="$1"
+  has_word "$seg" "git" || return 0
+  if has_word "$seg" "push"; then
+    # --force-with-lease is the SAFE variant — strip it before looking for --force, or
+    # the safe form is denied by its own prefix. `+refspec` is force-push in disguise.
+    local no_lease="${seg//--force-with-lease/}"
+    if has_word "$no_lease" "-f" || has_word "$no_lease" "--force"; then
+      deny "'git push --force' rewrites remote history. Use --force-with-lease, or get explicit user approval."
+    fi
+    if [[ "$seg" =~ (^|[[:space:]])\+[^[:space:]]+ ]]; then
+      deny "'git push' with a +refspec is a force push. Use --force-with-lease, or get explicit user approval."
+    fi
+  fi
+  if has_word "$seg" "reset" && has_word "$seg" "--hard"; then
+    deny "'git reset --hard' discards uncommitted work irrecoverably."
+  fi
+  if has_word "$seg" "branch"; then
+    if has_word "$seg" "-D" || { { has_word "$seg" "-d" || has_word "$seg" "--delete"; } && { has_word "$seg" "-f" || has_word "$seg" "--force"; }; }; then
+      deny "'git branch -D' deletes a branch regardless of merge state. Use -d, or get explicit user approval."
+    fi
+  fi
+  if has_word "$seg" "clean"; then
+    if [[ "$seg" =~ (^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$) ]] || has_word "$seg" "--force"; then
+      deny "'git clean -f' deletes untracked files irrecoverably. Preview with 'git clean -n', or get explicit user approval."
+    fi
+  fi
+}
+
+check_rm_segment() {
+  local seg="$1"
+  [[ "$seg" =~ (^|[[:space:]])(sudo[[:space:]]+)?rm[[:space:]] ]] || return 0
+  if [[ "$seg" =~ (^|[[:space:]])-[a-zA-Z]*[rR][a-zA-Z]*([[:space:]]|$) ]] || has_word "$seg" "--recursive"; then
+    # Catastrophic targets only: root, home, cwd/parent wholesale, glob-all, repo history.
+    # A bare "$VAR" target was considered and rejected: empty expansion makes rm a no-op
+    # ("" is an error, not /) — the noise would outweigh the protection.
+    if [[ "$seg" =~ (^|[[:space:]])(/|/\*|~|~/|~/\*|\$HOME(/\*?)?|\$\{HOME\}(/\*?)?|\.|\.\.|\./|\.\./|\.git/?|\*)([[:space:]]|$) ]]; then
+      deny "recursive rm of a catastrophic target (/, ~, ., .., *, or .git). Name the specific subdirectory instead."
+    fi
+  fi
+}
+
+# Split compound commands so `cd /tmp && rm -rf /` is judged per segment, and a
+# destructive command cannot hide behind a benign first half.
+SEGMENTS=$(printf '%s\n' "$NORM" | awk '{gsub(/[;&|]+/, "\n")} 1')
+while IFS= read -r seg; do
+  check_git_segment "$seg"
+  check_rm_segment "$seg"
+done <<<"$SEGMENTS"
+
+exit 0

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -4,6 +4,7 @@
       {
         "matcher": "Bash",
         "hooks": [
+          { "type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/block-destructive-commands.sh", "timeout": 10 },
           { "type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/quality-before-commit.sh", "timeout": 120 }
         ]
       },

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -223,6 +223,70 @@ else
 fi
 rm -rf "$sqc_t"
 
+# --- Tier 1: destructive-command denials --------------------------------------------
+head_ "Destructive-command hook"
+
+# block-destructive-commands.sh is the mechanical form of llm-security.md's "never run
+# push --force / reset --hard / branch -D without explicit user request". Guard both
+# directions: the denials (or the guidance is prose again) AND the allows (a false
+# positive on commit messages or --force-with-lease gets the hook disabled, which is
+# worse than never shipping it).
+BDC="$REPO/hooks/block-destructive-commands.sh"
+bdc_case() { # expected-exit command description
+  local exp="$1" cmd="$2" desc="$3" rc=0
+  jq -n --arg c "$cmd" '{tool_input:{command:$c}}' | bash "$BDC" >/dev/null 2>&1 || rc=$?
+  if [ "$rc" = "$exp" ]; then ok "$desc"
+  else bad "$desc (want exit $exp, got $rc)"; fi
+}
+bdc_case 2 'git push --force origin main'        "denies git push --force"
+bdc_case 2 'git reset --hard HEAD~1'             "denies git reset --hard"
+bdc_case 2 'git branch -D feature/x'             "denies git branch -D"
+bdc_case 2 'git clean -fdx'                      "denies git clean -f"
+bdc_case 2 'rm -rf /'                            "denies rm -rf /"
+bdc_case 2 'cd /tmp && rm -rf ~'                 "denies rm -rf ~ behind a compound command"
+bdc_case 0 'git push --force-with-lease origin main' "allows --force-with-lease (the safe variant is not its own prefix's victim)"
+# The denied token must sit MID-message: at message end the closing quote itself breaks
+# the word boundary, and the case passes even with quote-stripping deleted — a guard that
+# survived its own mutation test, which is exactly what this suite exists to prevent.
+bdc_case 0 'git commit -m "docs: never run git reset --hard in scripts"' "allows a commit message that MENTIONS a denied command (data, not command)"
+bdc_case 0 'rm -rf node_modules'                 "allows rm -rf of a named subdirectory"
+# The repo's own commit style is a heredoc message; quote-stripping is line-based and
+# cannot see across lines, so heredoc bodies must be dropped before analysis. This false
+# positive was hit while building the hook — committing the hook tripped the hook.
+bdc_hd="$(printf 'git commit -m "$(cat <<%s\nfeat: deny git reset --hard\nEOF\n)"' "'EOF'")"
+bdc_case 0 "$bdc_hd" "allows a heredoc commit message mentioning a denied command"
+
+# The hook must also be REGISTERED on the Bash matcher — an unregistered hook exists,
+# is executable, passes every case above, and never fires. That is this suite's founding
+# failure mode (validates cleanly, never runs).
+bdc_reg="$(jq -r '.hooks.PreToolUse[] | select(.matcher == "Bash") | .hooks[].command' "$REPO/hooks/hooks.json")"
+if grep -qF 'block-destructive-commands.sh' <<<"$bdc_reg"; then
+  ok "destructive-command hook is registered on the Bash matcher"
+else
+  bad "block-destructive-commands.sh is not registered in hooks.json — it will never fire"
+fi
+
+# --- Tier 1: adf.sync prescribes cp, never mv ---------------------------------------
+head_ "adf.sync stow safety"
+
+# `mv` onto a stow symlink under ~/.claude/ replaces the symlink with a regular file and
+# the dotfiles repo silently stops receiving updates — this bit for real (settings.json).
+# adf.sync exists to FIX drift; it must never prescribe the command that causes it.
+sync_fenced="$(awk '/^```/{f=!f; next} f' "$REPO/commands/adf.sync.md" || true)"
+# `.*` not `[^\n]*` — grep is already line-based, and inside a bracket expression \n is
+# LITERAL backslash+n, so [^\n]* cannot cross any filename containing an 'n'. That version
+# passed its own mutation test's absence and missed a planted `mv new-rules.md ~/.claude/`.
+if grep -qE '(^|[[:space:]])mv[[:space:]].*~/\.claude/' <<<"$sync_fenced"; then
+  bad "adf.sync.md prescribes 'mv' into ~/.claude/ — that replaces a stow symlink with a plain file"
+else
+  ok "adf.sync.md never prescribes mv into ~/.claude/"
+fi
+if grep -qF 'Never `mv`' "$REPO/commands/adf.sync.md"; then
+  ok "adf.sync.md carries the stow-mv trap warning"
+else
+  bad "adf.sync.md lost the stow-mv trap warning — the next editor will prescribe mv"
+fi
+
 # --- Tier 1: the #7 regression guard ------------------------------------------------
 head_ "Command → helper wiring"
 


### PR DESCRIPTION
## Summary

Two mechanisms adopted from [YC's QM harness](https://github.com/yc-software/qm) command policy, which hard-denies destructive commands in every security posture:

- **`hooks/block-destructive-commands.sh`** (PreToolUse on Bash) — turns `llm-security.md`'s "never run `push --force` / `reset --hard` / `branch -D` without explicit user request" from prose into a mechanical denial, per the framework's own Defense-in-Depth thesis (prompting is not a mechanism). Also covers `git clean -f`, `+refspec` force pushes, and recursive `rm` of catastrophic targets (`/`, `~`, `$HOME`, `.`, `..`, `*`, `.git`). `--force-with-lease` stays allowed. `CLAUDE_ALLOW_DESTRUCTIVE=1` is the transcript-visible bypass for explicit user requests — same auditability bet as `CLAUDE_SKIP_VERIFY_GATE`.
- **`commands/adf.sync`** — reports drift across the three framework copies (installed plugin clone, `~/.claude/rules`, `origin/main`), using the clone itself as the upstream reference so it needs no machine-specific paths. Report-only; prescribes `cp`-never-`mv` for stow-symlinked targets.

## False positives found and fixed while building

- Quoted prose read as commands: `git commit -m "docs: never run git reset --hard"` was denied. Whitespace-free quoted tokens are unquoted (so `"$HOME"` stays matchable), then prose spans are deleted.
- Heredoc commit messages (this repo's own commit style) tripped the hook — quote-stripping is line-based. Heredoc bodies are dropped before analysis.
- A bare-`$VAR` rm target rule was considered and rejected: empty expansion makes `rm -rf ""` a no-op error, not a wipe — noise would outweigh protection.

## Verification

- 42-case behavioral table on the hook (denials, allows, compound commands, heredocs) — all pass.
- `/adf.sync` procedure executed end-to-end on a real machine (clone 0 behind, 5/5 rules identical, symlink reported).
- 13 new smoke guards; **six mutations run, all six red** (neutered denial, removed quote-stripping, removed heredoc-drop, deregistered hook, planted `mv` prescription, deleted stow warning). The mutation pass caught two broken guards before they shipped: a commit-message case that passed with quote-stripping deleted (closing quote broke the word boundary) and an `mv` guard whose `[^\n]*` could not cross a filename containing an `n`.
- Full suite: **74 passed, 0 failed**.

## Post-merge

- Mirror the `llm-security.md` change into dotfiles (rules ship in two places).
- `git -C ~/.claude-framework pull` + Claude Code reload to make the hook live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)