### PR TITLE
docs: drop hardcoded check counts from the README tests row

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ an upgrade — see [`docs/install.md`](docs/install.md).
 | 🧠 `skills/` | Systematic debugging, effort estimation, performance audit, plus reference skills promoted from rules (quality tooling, pipeline & MCP security, agent collaboration). |
 | 🔁 `workflows/` | `speckit-workflow.js` — executes a task list as a deterministic Workflow. |
 | 📏 `.claude/rules/` | The rules loaded into every session. **Not shipped by the plugin** — copy them yourself. |
-| 🧪 `tests/` | `smoke.sh` — the plugin's own test suite: 38 checks in CI, 42 with the live and end-to-end tiers. |
+| 🧪 `tests/` | `smoke.sh` — the plugin's own behavioral test suite: a structural + regression tier in CI, plus opt-in live and end-to-end tiers (`SMOKE_LIVE=1`). Every guard is mutation-tested. |
 | 📚 `docs/` | Everything below. |
 
 ---


### PR DESCRIPTION
## Summary

The `tests/` structure row claimed "38 checks in CI, 42 with the live and end-to-end tiers" while tier 1 alone reports 74 — the count had been stale since before #45 and gets staler with every guard added. Describe the tiers instead of counting them, so the row cannot rot again.

Flagged as out-of-scope in #47; this is its own commit per the surgical-changes rule.

## Verification

Suite on this tree: 74 passed, 0 failed (includes the docs link/consistency guards). No other check-count claims exist in README, docs/, or SETUP.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)