### PR TITLE
feat: model-tier routing for commands, agents, and workflow spawns

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -34,7 +34,8 @@ For general tasks, use built-in agents: `Explore` (codebase search), `Plan` (arc
 - **Fast Mode**: Toggle with `/fast` for faster Opus output on quick iterations, bug fixes, and exploration (uses Opus, not a smaller model)
 - **Ultrathink**: Type `ultrathink` in any prompt to bump that turn to high reasoning effort (reverts after response)
 - Effort levels: `max` (via `/model` only) > `high` (ultrathink keyword) > `medium` (default) > `low`
-- Agents default to adaptive model selection — override with `model:` in agent frontmatter only when needed
+- **Model-tier routing (deliberate policy)**: aliases name tiers, not models — `fable` = strategy/judgment (spec pipeline, code review, security forensics, workflow verification), `opus` = execution/generation (implement, fix, tests, PR creation/summaries, quality checks, workflow gates), `sonnet` = mechanical (adf.sync, adf.context, repo-scout). Commands, agents, and workflow spawns pin tiers via alias frontmatter/opts
+- NEVER put a concrete model ID in framework frontmatter or workflow opts — each environment binds the aliases: personal `claude` uses the built-in mappings + the Fable 5 session default; `claude-bedrock()` remaps them via `ANTHROPIC_DEFAULT_{FABLE,OPUS,SONNET,HAIKU}_MODEL` to Bedrock-available models. An alias a backend can't serve silently falls back to the session model — benign by design
 - Use `haiku` for lightweight tasks (search, simple edits); `sonnet` for standard work; `opus` for complex architecture
 
 ## Multi-Environment Workflows

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,4 +1,5 @@
 ---
+model: fable
 name: code-reviewer
 description: Use PROACTIVELY for code review before PR creation. Two-stage review specialist for spec compliance and code quality. Separate from review-coordinator (which handles PR lifecycle). Examples: <example>Context: Pre-PR review. user: 'Review the code before we create a PR' assistant: 'I'll use code-reviewer for a two-stage review' <commentary>Dedicated review before PR lifecycle.</commentary></example> <example>Context: Plan compliance check. user: 'Does this implementation match the spec?' assistant: 'Let me use code-reviewer for spec compliance analysis' <commentary>Validates implementation against original plan.</commentary></example>
 color: green

--- a/agents/forensic-specialist.md
+++ b/agents/forensic-specialist.md
@@ -1,4 +1,5 @@
 ---
+model: fable
 name: forensic-specialist
 description: Use PROACTIVELY for security audits or when suspicious patterns detected. Cybersecurity specialist for defensive forensics, threat hunting, malware investigation, and IOC generation with proper chain of custody. Examples: <example>Context: Suspected compromise. user: 'System may be compromised, analyze it' assistant: 'I'll use forensic-specialist for IOC analysis' <commentary>Defensive security analysis.</commentary></example> <example>Context: Suspicious file. user: 'Analyze this suspicious file' assistant: 'Let me use forensic-specialist for threat analysis' <commentary>Malware analysis with forensic practices.</commentary></example>
 color: purple

--- a/agents/quality-guardian.md
+++ b/agents/quality-guardian.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 name: quality-guardian
 description: MUST BE USED before any commit, PR creation, or merge. Use PROACTIVELY after implementation phases complete. Phase 2-3 specialist for linting, type checking, security scans, and performance validation. Examples: <example>Context: Before commit. user: 'Quality validation needed' assistant: 'I'll use quality-guardian for comprehensive checks' <commentary>Quality gate before integration.</commentary></example> <example>Context: Module validation. user: 'Run quality checks for payment module' assistant: 'Let me use quality-guardian for validation' <commentary>Automated QA with reporting.</commentary></example>
 color: red

--- a/agents/review-coordinator.md
+++ b/agents/review-coordinator.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 name: review-coordinator
 description: Use when creating PRs or managing review workflows. Phase 3 specialist for pull request creation, review coordination, and merge management. Examples: <example>Context: PR creation. user: 'Quality checks passed, create a PR' assistant: 'I'll use review-coordinator for PR creation' <commentary>PR creation after validation.</commentary></example> <example>Context: Review feedback. user: 'Handle review feedback and merge' assistant: 'Let me use review-coordinator for integration' <commentary>Complete review lifecycle management.</commentary></example>
 color: cyan

--- a/agents/test-specialist.md
+++ b/agents/test-specialist.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 name: test-specialist
 description: Use PROACTIVELY after implementation to create comprehensive tests. Phase 2 specialist for test creation, validation, and ensuring reasonable coverage following existing test patterns. Examples: <example>Context: After implementation. user: 'I implemented auth and need tests' assistant: 'I'll use test-specialist for comprehensive test coverage' <commentary>Tests follow implementation.</commentary></example> <example>Context: Complex module testing. user: 'Test the payment processing module' assistant: 'Let me use test-specialist for payment tests' <commentary>Handles test design and coverage validation.</commentary></example>
 color: purple

--- a/commands/adf.agent.md
+++ b/commands/adf.agent.md
@@ -1,4 +1,5 @@
 ---
+model: fable
 description: "Coordinate a development task with full workflow"
 argument-hint: "development task description"
 ---

--- a/commands/adf.context.md
+++ b/commands/adf.context.md
@@ -1,4 +1,5 @@
 ---
+model: sonnet
 description: "Refresh project context analysis"
 ---
 

--- a/commands/adf.pr-summary.md
+++ b/commands/adf.pr-summary.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 description: "Generate PR summary from current branch"
 ---
 

--- a/commands/adf.quality.md
+++ b/commands/adf.quality.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 description: "Run comprehensive quality checks"
 ---
 

--- a/commands/adf.security-scan.md
+++ b/commands/adf.security-scan.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 description: "Quick security scan of current changes"
 ---
 

--- a/commands/adf.sync.md
+++ b/commands/adf.sync.md
@@ -1,4 +1,5 @@
 ---
+model: sonnet
 description: "Check the three framework copies (installed plugin, global rules, upstream) are in sync"
 ---
 

--- a/commands/speckit.analyze.md
+++ b/commands/speckit.analyze.md
@@ -1,4 +1,5 @@
 ---
+model: fable
 description: "Read-only cross-artifact consistency analysis with coverage mapping"
 ---
 

--- a/commands/speckit.baseline.md
+++ b/commands/speckit.baseline.md
@@ -1,4 +1,5 @@
 ---
+model: fable
 description: "Reverse-engineer specs from existing code for brownfield projects"
 argument-hint: "<module or directory to baseline>"
 ---

--- a/commands/speckit.brainstorm.md
+++ b/commands/speckit.brainstorm.md
@@ -1,4 +1,5 @@
 ---
+model: fable
 description: "Socratic design exploration before specification — refine the idea before committing to requirements"
 argument-hint: "<idea or problem to explore>"
 ---

--- a/commands/speckit.checklist.md
+++ b/commands/speckit.checklist.md
@@ -1,4 +1,5 @@
 ---
+model: fable
 description: "Generate requirement quality checklists for pre-implementation validation"
 ---
 

--- a/commands/speckit.clarify.md
+++ b/commands/speckit.clarify.md
@@ -1,4 +1,5 @@
 ---
+model: fable
 description: "Scan spec for ambiguities and ask targeted clarification questions"
 ---
 

--- a/commands/speckit.constitution.md
+++ b/commands/speckit.constitution.md
@@ -1,4 +1,5 @@
 ---
+model: fable
 description: "Create or update .specify/memory/constitution.md with project governance principles"
 ---
 

--- a/commands/speckit.fix.md
+++ b/commands/speckit.fix.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 description: "Quick-fix bypass for trivial changes that skip the full SDD workflow"
 argument-hint: "<description of trivial change>"
 ---

--- a/commands/speckit.implement.md
+++ b/commands/speckit.implement.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 description: "Execute TDD implementation from spec-kit artifacts with quality gates"
 ---
 

--- a/commands/speckit.plan.md
+++ b/commands/speckit.plan.md
@@ -1,4 +1,5 @@
 ---
+model: fable
 description: "Generate implementation plan from spec, with research, design, and constitution compliance"
 ---
 

--- a/commands/speckit.review.md
+++ b/commands/speckit.review.md
@@ -1,4 +1,5 @@
 ---
+model: fable
 description: "Read-only plan review gate before task generation"
 ---
 

--- a/commands/speckit.specify.md
+++ b/commands/speckit.specify.md
@@ -1,4 +1,5 @@
 ---
+model: fable
 description: "Generate a feature specification with scenarios, requirements, and success criteria"
 argument-hint: "<feature description>"
 ---

--- a/commands/speckit.tasks.md
+++ b/commands/speckit.tasks.md
@@ -1,4 +1,5 @@
 ---
+model: fable
 description: "Generate phased task list from plan and spec, with Claude Code task tracker integration"
 ---
 

--- a/workflows/speckit-workflow.js
+++ b/workflows/speckit-workflow.js
@@ -696,6 +696,10 @@ async function implementAndVerify(task) {
   const impl = await agentTyped(implPrompt(task, ctx, repo), {
     label: `impl:${task.id}`,
     phase: 'Implement',
+    // Tier routing: implementation is generation work — execution tier ('opus'), not the session's
+    // strategy tier. Aliases only; each environment binds them (claude-bedrock() remaps via
+    // ANTHROPIC_DEFAULT_*_MODEL), so no concrete model ID may appear here.
+    model: 'opus',
     schema: IMPL_SCHEMA,
   })
   if (!impl) return { task, accepted: false, reason: 'implementer died or was skipped' }
@@ -717,6 +721,10 @@ async function implementAndVerify(task) {
       agentTyped(verifyPrompt(task, impl, lens, ctx, repo), {
         label: `verify:${task.id}:${lens.key}`,
         phase: 'Verify',
+        // Tier routing: adversarial verification is judgment — strategy tier ('fable'). On backends
+        // without a Fable model the alias resolves via ANTHROPIC_DEFAULT_FABLE_MODEL or falls back
+        // to the session model, both benign.
+        model: 'fable',
         schema: VERDICT_SCHEMA,
       }).then(v => (v ? { ...v, lens: lens.key } : { lens: lens.key, silent: true })),
     ),
@@ -836,6 +844,10 @@ for (const ph of ctx.phases) {
       agentTyped(gatePrompt(repo, ctx), {
         label: `gate:${ph.name}:${repo.path.split('/').pop() || repo.path}`,
         phase: 'Implement',
+        // Tier routing: the gate only runs the suite and reports — mechanical, so execution tier at
+        // low effort. The gate's authority is the suite's exit code, not the agent's reasoning.
+        model: 'opus',
+        effort: 'low',
         schema: GATE_SCHEMA,
       }).then(g => ({ repo, g })),
     ),


### PR DESCRIPTION
## Summary
- Pin model tiers by alias across the framework: `fable` = strategy/judgment (spec pipeline, code-reviewer, forensic-specialist, workflow Verify spawns), `opus` = execution/generation (implement, fix, PR surfaces, quality, test-specialist, review-coordinator, quality-guardian, workflow Implement spawns and phase gates at low effort), `sonnet` = mechanical (adf.sync, adf.context).
- Aliases only, never concrete model IDs: each environment binds them — personal `claude` via built-in mappings + session default, `claude-bedrock()` via `ANTHROPIC_DEFAULT_{FABLE,OPUS,SONNET,HAIKU}_MODEL` remaps (dotfiles side, committed separately). An alias a backend can't serve silently falls back to the session model.
- Policy documented in `.claude/CLAUDE.md` (Performance & Model Selection).

## Test plan
- `tests/smoke.sh`: 74 passed, 0 failed
- `node --test tests/workflow.test.js`: 67 passed, 0 failed
- Frontmatter check: all 25 command/agent files carry exactly one `model:` line with a valid alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)