### PR TITLE
fix: plugin fails to load on fresh installs (duplicate hooks + dead MCP)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -27,7 +27,5 @@
     "./agents/review-coordinator.md",
     "./agents/test-specialist.md"
   ],
-  "hooks": "./hooks/hooks.json",
-  "workflows": "./workflows/",
-  "mcpServers": "./.mcp.json"
+  "workflows": "./workflows/"
 }


### PR DESCRIPTION
## Summary
- Remove `"hooks": "./hooks/hooks.json"` — current Claude Code auto-loads the standard hooks file, so the explicit declaration now fails fresh installs with "Duplicate hooks file detected" (surfaced by the first install into the isolated claude-bedrock profile; long-standing installs carry an older snapshot and never re-parse the manifest).
- Remove `"mcpServers": "./.mcp.json"` — the bundled github MCP has never connected on any profile (`${GITHUB_TOKEN}` doesn't expand in Claude's env → malformed Bearer header) and the framework's documented GitHub path is the `gh` CLI. `.mcp.json` stays project-scoped for repo contributors; `docs/mcp.md` unchanged.

## Test plan
- `tests/smoke.sh`: 72 passed, 0 failed (2 fewer checks — the manifest-path loop validates 2 fewer declared keys, by design)
- Fresh-install repro: `claude plugin install` into the bedrock profile reproduces both errors before the fix; will re-verify clean load after merge + `~/.claude-framework` pull

🤖 Generated with [Claude Code](https://claude.com/claude-code)