### PR TITLE
fix(tests): make the live smoke tier able to pass, and able to fail

### DIFF
--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -698,11 +698,31 @@ if [ "${SMOKE_LIVE:-0}" = "1" ]; then
   broken=0
   while read -r invocation; do
     real="${invocation//\$\{CLAUDE_PLUGIN_ROOT\}/$ROOT}"
-    if ! (cd "$SCRATCH" && eval "$real") >/dev/null 2>&1; then
+    err="$( (cd "$SCRATCH" && eval "$real") 2>&1 >/dev/null )"
+    code=$?
+    # A non-zero exit is NOT itself a defect. The helper is REQUIRED to exit non-zero and name
+    # the missing artifact when one is absent - the fetcher contract above asserts exactly that -
+    # and this scratch repo deliberately has no .specify/, so ~8 subcommands correctly report a
+    # miss. Scoring those as failures is what made this tier read 13-red for months (#56) and
+    # buried the real bug underneath the noise. Only two outcomes mean the INVOCATION is broken:
+    #   126/127          - script missing or not executable (the aa32e83 bug shape)
+    #   Unknown command: - the subcommand was renamed or deleted out from under the doc
+    if [ "$code" -eq 127 ] || [ "$code" -eq 126 ] || grep -qF 'Unknown command:' <<<"$err"; then
       bad "command invocation fails as the model would run it: $real"
       broken=$((broken + 1))
     fi
-  done < <(grep -rhoE '\$\{CLAUDE_PLUGIN_ROOT\}[^`]+' "$REPO/commands/" | sort -u)
+  done < <({
+    # Capture the WHOLE fenced span, not just the tail from ${CLAUDE_PLUGIN_ROOT} onward. Anchoring
+    # at the variable silently dropped any command PREFIX: `git -C "${CLAUDE_PLUGIN_ROOT}" status`
+    # extracted as `${CLAUDE_PLUGIN_ROOT}" status`, losing `git -C "` and keeping the stray quote,
+    # so eval tried to execute the plugin path itself. Those five hef.sync invocations could only
+    # ever fail, which means they were never actually validated - the precise blind spot the note
+    # below says this test exists to close (#56).
+    grep -rhoE '`[^`]*\$\{CLAUDE_PLUGIN_ROOT\}[^`]*`' "$REPO/commands/" | sed 's/^`//; s/`$//'
+    # Fenced code blocks carry the invocation bare, with no inline backticks on the line.
+    grep -rh '\${CLAUDE_PLUGIN_ROOT}' "$REPO/commands/" | grep -v '`' | sed -E 's/^[[:space:]]+//'
+  } | grep -vE '<[a-z-]+>' | sort -u)
+  # `<placeholder>` invocations are documentation templates, not runnable commands.
   # NB: match ANY ${CLAUDE_PLUGIN_ROOT} invocation, not just speckit-helper.sh. Hardcoding
   # the script name here creates the exact blind spot this test exists to close: a command
   # pointing at a script that does not exist would never be matched, so never executed, so


### PR DESCRIPTION
Closes #56.

## Result

| | before | after |
|---|---|---|
| structural (`bash tests/smoke.sh`) | 72 / 0 | **72 / 0** |
| live (`SMOKE_LIVE=1`) | 75 / **13** | **76 / 0** |

All 13 failures were defects in the *test*. None was a defect in the plugin.

## Cause A — the pass criterion contradicted a sibling assertion

The check ran each invocation in a bare scratch repo and scored **any** non-zero exit as broken. But the helper is *required* to exit non-zero and name the missing artifact when one is absent — the fetcher contract asserts exactly that — and the scratch repo deliberately has no `.specify/`:

```
$ (cd "$SCRATCH" && speckit-helper.sh constitution); echo $?
no constitution: .specify/memory/constitution.md does not exist. Run /…
1
```

Eight subcommands did the right thing and were marked failures. The criterion is now the two outcomes that actually mean the invocation is broken:

- **126/127** — script missing or not executable (the `aa32e83` bug shape)
- **`Unknown command:`** at runtime — subcommand renamed or deleted

## Cause B — the extractor dropped command prefixes

Anchoring at `${CLAUDE_PLUGIN_ROOT}` captured only the tail:

```
source:    `git -C "${CLAUDE_PLUGIN_ROOT}" status --porcelain`
extracted:  ${CLAUDE_PLUGIN_ROOT}" status --porcelain
evaluated:  /path/to/plugin/" status --porcelain      ← tries to execute the path
```

`git -C "` lost, stray quote kept. **Those five `hef.sync` invocations could only ever fail, so they were never actually validated** — the exact blind spot the comment beside this test says it exists to close. It now captures the whole fenced span, plus the one invocation that lives bare inside a code fence (`speckit.plan.md:164`), and skips `<placeholder>` templates that are documentation rather than runnable commands.

## Verified by mutation, not by the suite turning green

| Mutation | Caught? |
|---|---|
| Point a command at a script that does not exist | ✅ by this check (127 path) |
| Rename a subcommand out from under the doc | ✅ — but by the **pre-existing structural check**, not this one |

Being precise about the second: the `Unknown command:` branch here is a *runtime backstop for a static check*, not the primary guard. It's kept for the narrow case of a subcommand that is dispatched but broken. I'd rather state that than claim mutation coverage this change doesn't have.

Worth recording: **two earlier mutation attempts silently matched nothing and "passed"** — `sed` is happy to change zero lines. The runs above assert the file actually changed before drawing any conclusion. A mutation test that doesn't mutate proves nothing, and looks identical to success.

## For the CI question in #56

Fixing Cause B means five `git -C` invocations now genuinely execute — including **`git fetch --quiet origin`**. This tier now performs **network I/O**, which it never did before. One run out of five showed a transient `75/1`; three consecutive runs afterwards were clean. That is the thing to weigh before wiring this tier into CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
