### PR TITLE
docs: document per-profile plugin installation

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -73,6 +73,8 @@ claude plugin list
 
 Expect `hefesto@hefesto` with `Status: ✔ enabled`. This writes `enabledPlugins` into `~/.claude/settings.json`, so the install is persistent and user-scoped: it applies to every project, with no flags.
 
+> **Running more than one profile?** `~/.claude` is the *default* config directory. Plugins, marketplaces and `settings.json` all live inside whatever `CLAUDE_CONFIG_DIR` points at, so each additional profile needs this step run once on its own — `export CLAUDE_CONFIG_DIR=...` first, then the two commands above. The clone is shared, so updates still only need one `git pull`. See [docs/install.md](docs/install.md#installing-into-more-than-one-profile).
+
 ## Step 4 — Add the helper permission rule (required in practice)
 
 Most spec-kit commands gather live project data by running `speckit-helper.sh` with the Bash

--- a/docs/install.md
+++ b/docs/install.md
@@ -15,7 +15,7 @@ claude plugin marketplace add ~/.claude-framework
 claude plugin install hefesto@hefesto
 ```
 
-That is a **persistent, user-scoped** install: it writes `enabledPlugins` to `~/.claude/settings.json` and applies to every project, in every session, with no flags. Confirm it:
+That is a **persistent, user-scoped** install: it writes `enabledPlugins` to `~/.claude/settings.json` and applies to every project, in every session, with no flags. (`~/.claude` is the *default* config directory — if you run more than one, see *Installing into more than one profile* below.) Confirm it:
 
 ```bash
 claude plugin list          # → hefesto@hefesto  ✔ enabled
@@ -46,6 +46,24 @@ Plugin components are **namespaced by plugin name**, but the namespace is only *
 | **Commands** | `/hef.context`, `/speckit.plan`, `/hef.quality` — the bare name works. The `hefesto:` prefix also works, and disambiguates if another plugin defines the same name. |
 | **Agents** | Dispatched by Claude, or by name — they appear as `hefesto:code-reviewer`. |
 | **The workflow** | **Must be namespaced**: `hefesto:speckit-workflow`. A bare `speckit-workflow` **does not resolve**. |
+
+#### Installing into more than one profile
+
+`~/.claude` is the **default** config directory, not the only one. Claude Code keys everything it stores to `CLAUDE_CONFIG_DIR`: installed plugins, registered marketplaces, `settings.json`, `.claude.json`, sessions and memory all live *inside* it. So pointing that variable somewhere else — to run a second account, or to keep client work separate from personal — hands you a profile with **no plugin installed**. As in step 3, the absence is silent: the `/` menu simply comes up short.
+
+Install once per profile:
+
+```bash
+export CLAUDE_CONFIG_DIR=~/.claude-work            # whatever that profile uses
+
+claude plugin marketplace add ~/.claude-framework
+claude plugin install hefesto@hefesto
+claude plugin list                                 # → hefesto@hefesto  ✔ enabled
+```
+
+**The clone is shared; only the enablement is per profile.** Because the marketplace source is a *directory* read in place, every profile runs the same working tree — so a single `git pull` updates all of them and you never keep a second copy. What each profile needs is its own one-time `marketplace add` + `install`.
+
+The gap in step 6 is per profile too. `rules/` and `CLAUDE.md` are copied *into a config directory*, so each profile needs its own copy — and its own re-copy after an upgrade.
 
 ### 2️⃣ Optional Configuration
 
@@ -129,6 +147,8 @@ claude plugin marketplace update hefesto   # re-read the manifest
 ```
 
 Restart Claude Code to pick up the new components. To check what changed first, read `CHANGELOG.md` in the clone.
+
+One pull covers **every** profile, since they all read this same clone. Only `claude plugin marketplace update` is per profile, and only for profiles you actually run.
 
 ### 6️⃣ The two things the plugin cannot ship
 


### PR DESCRIPTION
Closes a real gap for anyone running more than one `CLAUDE_CONFIG_DIR`.

## The problem

Claude Code keys **everything** it stores to `CLAUDE_CONFIG_DIR` — installed plugins, registered marketplaces, `settings.json`, `.claude.json`, sessions and memory all live inside it. So a second config directory (a separate account, or client work kept apart from personal) gets a profile with **no plugin installed**, and nothing says so. The `/` menu just comes up short — the same *silent absence* failure step 3 already warns about, which is why the new section leans on that existing framing rather than inventing one.

Neither `docs/install.md` nor `SETUP.md` mentioned this, and both stated the install "writes `enabledPlugins` into `~/.claude/settings.json`" as though that path were fixed.

## Verified, not assumed

Every claim was executed against a throwaway config dir on `claude 2.1.245`:

| Claim | Evidence |
|---|---|
| A fresh profile has no plugin | `No plugins installed.` |
| The documented commands work verbatim | `✔ Successfully installed plugin: hefesto@hefesto` |
| Enablement is **per profile** | `enabledPlugins: {"hefesto@hefesto":true}` landed in *that profile's* `settings.json`, not `~/.claude` |
| The clone is shared, not copied | `installLocation=/home/ariedi/.claude-framework` — so one `git pull` updates every profile |

The pre-existing `enabledPlugins`-in-`settings.json` claim was checked too, before writing around it.

## Changes

- **`docs/install.md`** — new `#### Installing into more than one profile` at the end of step 1; the `~/.claude` claim now flags that it is the *default* dir; step 5 notes one pull covers all profiles.
- **`SETUP.md`** — pointer after its Step 3, which carried the same `~/.claude`-specific claim.

Also records that the step 6 gap is per profile: `rules/` and `CLAUDE.md` are copied *into a config directory*, so each profile needs its own copy and its own re-copy after an upgrade. That follows from the same fact and was not stated anywhere.

## Verification

`bash tests/smoke.sh` → **72 passed, 0 failed**

Docs-only; no component, hook or manifest touched. The example uses a generic `~/.claude-work`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
